### PR TITLE
Fix spawn side and update server modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Running the Server
 1. In the terminal, run the following command to start the server:
    ```bash
-   node app.js
+   node server.js
    ```
 2. Open your web browser and go to `http://localhost:3000` to access the PC game screen.
 3. Use the generated QR code to join the game from a mobile device.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "2dmultiplayer",
   "version": "1.0.0",
-  "main": "app.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/models/gameState.js
+++ b/src/models/gameState.js
@@ -6,7 +6,9 @@ module.exports = {
     scoreRed: 0,
     gameStarted: false,
     gameStartTime: null,
-    gameDuration: 10 * 60 * 200  // 2 minutes in ms
+    gameDuration: 10 * 60 * 200,  // 2 minutes in ms
+    canvasWidth: 800,
+    canvasHeight: 600
     // Additional state properties can be added as needed
   };
   

--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -146,9 +146,11 @@ function createBulletWithAngle(player, angle) {
 }
 
 function spawnPlayer(player) {
-  // Reset player's lives and position
+  // Reset player's lives and position based on team
   player.lives = 3;
-  player.x = (player.team === 'left') ? 100 : gameState.canvasWidth - 100;
+  player.x = player.team === 'left'
+    ? 100
+    : gameState.canvasWidth - 100;
   player.y = gameState.canvasHeight / 2;
   player.lastShotTime = Date.now();
   if (player.shieldMax > 0) {
@@ -164,4 +166,4 @@ function stopGameLoop() {
   }
 }
 
-module.exports = { startGameLoop, stopGameLoop };
+module.exports = { startGameLoop, stopGameLoop, spawnPlayer };


### PR DESCRIPTION
## Summary
- default entry is now `server.js`
- document new start command
- store canvas dimensions in `gameState`
- export `spawnPlayer` and use it in the socket handler
- assign teams correctly and handle game control events

## Testing
- `node -c src/services/socketHandler.js`
- `node -c server.js`
- `node server.js` *(fails: addMembership ENODEV)*

------
https://chatgpt.com/codex/tasks/task_e_684a7739b28c83289ac184bf0d17493e