### PR TITLE
Fix XP timing and show upgrade buttons

### DIFF
--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -29,7 +29,9 @@ function startGameLoop(io) {
       if (player.y > gameState.canvasHeight - player.radius) player.y = gameState.canvasHeight - player.radius;
       
       // Leveling and auto-fire
-      player.exp += 0.5 / 60;
+      if (gameState.gameStarted) {
+        player.exp += 0.5 / 60;
+      }
       if (player.exp >= 10) {
         player.exp -= 10;
         player.level++;

--- a/views/mobile.ejs
+++ b/views/mobile.ejs
@@ -197,6 +197,8 @@
       document.getElementById('stat-damage').innerText = myPlayer.bulletDamage;
       document.getElementById('stat-speed').innerText = myPlayer.bulletSpeed;
       document.getElementById('stat-up').innerText = myPlayer.upgradePoints;
+      document.getElementById('upgradePanel').style.display =
+        myPlayer.upgradePoints > 0 ? 'grid' : 'none';
     }
     
     function updateJoystickColor() {


### PR DESCRIPTION
## Summary
- only award experience after the match starts
- display upgrade buttons on mobile once points are available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a925523088328ab5cf43e80088726