### PR TITLE
Implement time-based level cap and team join list

### DIFF
--- a/src/models/gameState.js
+++ b/src/models/gameState.js
@@ -6,7 +6,8 @@ module.exports = {
     scoreRed: 0,
     gameStarted: false,
     gameStartTime: null,
-    gameDuration: 10 * 60 * 200,  // 2 minutes in ms
+    gameDuration: 2 * 60 * 1000,  // default 2 minutes in ms
+    levelCap: 1,
     canvasWidth: 800,
     canvasHeight: 600
     // Additional state properties can be added as needed

--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -33,10 +33,15 @@ function startGameLoop(io) {
         player.exp += 0.5 / 60;
       }
       if (player.exp >= 10) {
-        player.exp -= 10;
-        player.level++;
-        player.upgradePoints++;
-        if (player.shieldMax > 0) player.shield = player.shieldMax;
+        const cap = player.maxLevel || gameState.levelCap || Infinity;
+        if (player.level < cap) {
+          player.exp -= 10;
+          player.level++;
+          player.upgradePoints++;
+          if (player.shieldMax > 0) player.shield = player.shieldMax;
+        } else {
+          player.exp = 10;
+        }
       }
       
       if (gameState.gameStarted && now - player.lastShotTime >= player.bulletCooldown) {
@@ -159,6 +164,7 @@ function spawnPlayer(player) {
     player.shield = player.shieldMax;
     player.lastShieldRepair = Date.now();
   }
+  player.maxLevel = gameState.levelCap;
 }
 
 function stopGameLoop() {

--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -2,6 +2,16 @@
 const gameState = require('../models/gameState');
 const { spawnPlayer } = require('./gameLogic');
 
+const TOTAL_UPGRADE_LEVELS = 14; // sum of all upgrade max values
+
+function computeLevelCap(minutes) {
+  const ratio = Math.min(minutes, 10) / 10;
+  return Math.floor(TOTAL_UPGRADE_LEVELS * 0.75 * Math.pow(ratio, 0.7)) + 1;
+}
+
+// set initial level cap based on default duration
+gameState.levelCap = computeLevelCap(gameState.gameDuration / 60000);
+
 const TEAM_COLORS = {
   left: { fill: '#007BFF', border: '#0056b3' },
   right: { fill: '#FF4136', border: '#d62d20' }
@@ -45,6 +55,7 @@ function initSocket(io) {
         upgrades: {},
         lastShotTime: Date.now()
       };
+      gameState.players[socket.id].maxLevel = gameState.levelCap;
       spawnPlayer(gameState.players[socket.id]);
       socket.emit('playerInfo', gameState.players[socket.id]);
     });
@@ -57,7 +68,10 @@ function initSocket(io) {
     socket.on('setGameTime', (minutes) => {
       const m = parseFloat(minutes);
       if (!isNaN(m) && m > 0) {
-        gameState.gameDuration = m * 60 * 1000;
+        const clamped = Math.min(m, 10);
+        gameState.gameDuration = clamped * 60 * 1000;
+        gameState.levelCap = computeLevelCap(clamped);
+        Object.values(gameState.players).forEach(p => p.maxLevel = gameState.levelCap);
       }
     });
 

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -23,12 +23,12 @@
       margin-bottom: 5px;
       font-size: 18px;
     }
-    #playersNames {
+    #playersList ul {
       list-style: none;
       padding: 0;
       margin: 0;
     }
-    #playersNames li {
+    #playersList li {
       font-size: 16px;
       margin-bottom: 3px;
     }
@@ -52,12 +52,20 @@
       <h2>Scan to Join</h2>
       <canvas id="qrCode"></canvas>
       <div id="playersList">
-        <h4>Players Joined:</h4>
-        <ul id="playersNames" class="list-unstyled"></ul>
+        <div style="display:flex;justify-content:space-between;gap:20px;">
+          <div>
+            <h4>Left Team</h4>
+            <ul id="playersLeft" class="list-unstyled"></ul>
+          </div>
+          <div>
+            <h4>Right Team</h4>
+            <ul id="playersRight" class="list-unstyled"></ul>
+          </div>
+        </div>
       </div>
       <br>
       <label for="gameTimeInput">Game Time (minutes):</label>
-      <input type="number" id="gameTimeInput" value="10" min="1">
+      <input type="number" id="gameTimeInput" value="10" min="1" max="10">
       <br>
       <button id="setGameTimeButton">Set Game Time</button>
       <br>
@@ -104,12 +112,15 @@
       document.getElementById('timer').innerText = 'Time: ' + data.gameTimer + 's';
       document.getElementById('scoreboard').innerText = 'Blue: ' + data.scoreBlue + ' - Red: ' + data.scoreRed;
       if (!data.gameStarted) {
-        const playersNamesEl = document.getElementById('playersNames');
-        playersNamesEl.innerHTML = '';
+        const leftEl = document.getElementById('playersLeft');
+        const rightEl = document.getElementById('playersRight');
+        leftEl.innerHTML = '';
+        rightEl.innerHTML = '';
         Object.values(data.players).forEach(p => {
           const li = document.createElement('li');
           li.textContent = p.name || 'Unnamed';
-          playersNamesEl.appendChild(li);
+          if (p.team === 'left') leftEl.appendChild(li);
+          else rightEl.appendChild(li);
         });
       }
       drawGame(data);
@@ -153,6 +164,9 @@
         ctx.fillStyle = "#fff";
         ctx.textAlign = "center";
         ctx.fillText(`Lv:${player.level} L:${player.lives} S:${player.shield}`, player.x, player.y - player.radius - 12);
+        ctx.font = "bold 16px sans-serif";
+        ctx.fillStyle = "#000";
+        ctx.fillText(player.level, player.x, player.y + 5);
       }
     }
   </script>


### PR DESCRIPTION
## Summary
- cap level gains based on game duration
- clamp duration and compute cap in socket handler
- display team lists in join modal
- show level on player body

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b13306d9c83289c4c9e9b98018d99