### PR TITLE
Add start script and document npm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Running the Server
 1. In the terminal, run the following command to start the server:
    ```bash
-   node server.js
+   npm start
    ```
 2. Open your web browser and go to `http://localhost:3000` to access the PC game screen.
 3. Use the generated QR code to join the game from a mobile device.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add a start script in `package.json`
- document `npm start` for launching the server

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails: addMembership ENODEV)*

------
https://chatgpt.com/codex/tasks/task_e_684b177d3b5c8328810a7b0bfb4ffc94