### PR TITLE
Add bullet sprite example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@
 
 ## Stopping the Server
 - To stop the server, press `Ctrl + C` in the terminal where the server is running.
+
+## Adding Sprites
+
+Game artwork is served from the `public` folder. You can place image files there
+and reference them from the client code using `new Image()`.
+
+### Example: bullet sprite
+
+The game uses an SVG file at `public/bullet.svg` for bullet graphics. It is
+loaded in `views/game.ejs` like so:
+
+```javascript
+const bulletSprite = new Image();
+bulletSprite.src = "/bullet.svg"; // load sprite from the public folder
+```
+
+You can replace `bullet.svg` with your own image to customize bullets or add
+additional sprites in the same manner.

--- a/public/README.md
+++ b/public/README.md
@@ -1,1 +1,6 @@
 # Public assets
+
+This directory holds static files that are served by Express. Place images here
+if you want to use them as sprites.
+
+- `bullet.svg` &mdash; simple bullet image referenced by `views/game.ejs`.

--- a/public/bullet.svg
+++ b/public/bullet.svg
@@ -1,0 +1,3 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'>
+  <circle cx='8' cy='8' r='7' fill='#ffffff' stroke='#000000' stroke-width='2'/>
+</svg>

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -224,7 +224,7 @@
     const redSprite = new Image();
     redSprite.src = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%23FF4136' stroke='%23d62d20' stroke-width='4'/></svg>";
     const bulletSprite = new Image();
-    bulletSprite.src = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><circle cx='8' cy='8' r='7' fill='%23ffffff' stroke='%23000' stroke-width='2'/></svg>";
+    bulletSprite.src = "/bullet.svg"; // load sprite from the public folder
 
     function resizeCanvas(){
       canvas.width = window.innerWidth;


### PR DESCRIPTION
## Summary
- document how to add sprites and provide bullet example
- serve a simple bullet sprite from `public/`
- load the bullet sprite in `views/game.ejs`

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` *(fails: addMembership ENODEV)*

------
https://chatgpt.com/codex/tasks/task_e_684bc700718883289bd2eaff6e6773d7