### PR TITLE
Add bullet animation sprites for teams

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ app.set('view engine', 'ejs');
 
 // Serve static assets
 app.use(express.static(path.join(__dirname, 'public')));
+app.use('/assets', express.static(path.join(__dirname, 'assets')));
 
 // Compute joinURL (to be used in the game screen)
 const PORT = process.env.PORT || 3000;

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -223,8 +223,17 @@
     blueSprite.src = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%23007BFF' stroke='%230056b3' stroke-width='4'/></svg>";
     const redSprite = new Image();
     redSprite.src = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%23FF4136' stroke='%23d62d20' stroke-width='4'/></svg>";
-    const bulletSprite = new Image();
-    bulletSprite.src = "/bullet.svg"; // load sprite from the public folder
+    const bulletSprites = { left: [], right: [] };
+    function pad(num) { return num.toString().padStart(3, '0'); }
+    for (let i = 0; i < 8; i++) {
+      const r = new Image();
+      r.src = `/assets/Bullets/1/bullet${pad(i)}.png`;
+      bulletSprites.right.push(r);
+      const b = new Image();
+      b.src = `/assets/Bullets/2/tile${pad(i)}.png`;
+      bulletSprites.left.push(b);
+    }
+    let bulletFrameTick = 0;
 
     function resizeCanvas(){
       canvas.width = window.innerWidth;
@@ -324,8 +333,11 @@
       ctx.fillStyle = gradRight;
       ctx.fillRect(canvas.width / 2, 0, canvas.width / 2, canvas.height);
       
+      const frame = Math.floor(bulletFrameTick / 5) % 8;
+      bulletFrameTick++;
       data.bullets.forEach(bullet => {
-        ctx.drawImage(bulletSprite, bullet.x - bullet.radius, bullet.y - bullet.radius, bullet.radius * 2, bullet.radius * 2);
+        const img = bulletSprites[bullet.team][frame];
+        if (img) ctx.drawImage(img, bullet.x - bullet.radius, bullet.y - bullet.radius, bullet.radius * 2, bullet.radius * 2);
       });
       
       for (const id in data.players) {


### PR DESCRIPTION
## Summary
- serve `assets/` so images are available
- animate bullets using 8‑frame sprites from `assets/Bullets`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bd8e532508328aba10721fae77479