### PR TITLE
Add bullet animation sprites for teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,18 +30,23 @@
 Game artwork is served from the `public` folder. You can place image files there
 and reference them from the client code using `new Image()`.
 
-### Example: bullet sprite
+### Bullet sprites
 
-The game uses an SVG file at `public/bullet.svg` for bullet graphics. It is
-loaded in `views/game.ejs` like so:
+Animated bullet frames live under `assets/Bullets`. Folder `1` contains the
+sprites used for the red team and folder `2` for the blue team. Each folder holds
+eight PNGs. The client preloads them similar to:
 
 ```javascript
-const bulletSprite = new Image();
-bulletSprite.src = "/bullet.svg"; // load sprite from the public folder
+const bulletSprites = { left: [], right: [] };
+for (let i = 0; i < 8; i++) {
+  bulletSprites.right[i] = new Image();
+  bulletSprites.right[i].src = `/assets/Bullets/1/bullet${String(i).padStart(3, '0')}.png`;
+  bulletSprites.left[i] = new Image();
+  bulletSprites.left[i].src = `/assets/Bullets/2/tile${String(i).padStart(3, '0')}.png`;
+}
 ```
 
-You can replace `bullet.svg` with your own image to customize bullets or add
-additional sprites in the same manner.
+Update the paths if you reorganise the sprite folders.
 
 ## Sprite sheet splitter
 

--- a/public/README.md
+++ b/public/README.md
@@ -1,6 +1,5 @@
 # Public assets
 
-This directory holds static files that are served by Express. Place images here
-if you want to use them as sprites.
+This directory holds static files that are served by Express. Place images here if you want to use them as sprites for the game client.
 
-- `bullet.svg` &mdash; simple bullet image referenced by `views/game.ejs`.
+The bullet sprites used by the game are kept under `../assets/Bullets`.

--- a/public/bullet.svg
+++ b/public/bullet.svg
@@ -1,3 +1,0 @@
-<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'>
-  <circle cx='8' cy='8' r='7' fill='#ffffff' stroke='#000000' stroke-width='2'/>
-</svg>

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ app.set('view engine', 'ejs');
 
 // Serve static assets
 app.use(express.static(path.join(__dirname, 'public')));
+app.use('/assets', express.static(path.join(__dirname, 'assets')));
 
 // Compute joinURL (to be used in the game screen)
 const PORT = process.env.PORT || 3000;

--- a/src/models/gameState.js
+++ b/src/models/gameState.js
@@ -12,4 +12,4 @@ module.exports = {
     canvasHeight: 600
     // Additional state properties can be added as needed
   };
-  
+

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -223,8 +223,17 @@
     blueSprite.src = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%23007BFF' stroke='%230056b3' stroke-width='4'/></svg>";
     const redSprite = new Image();
     redSprite.src = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%23FF4136' stroke='%23d62d20' stroke-width='4'/></svg>";
-    const bulletSprite = new Image();
-    bulletSprite.src = "/bullet.svg"; // load sprite from the public folder
+    const bulletSprites = { left: [], right: [] };
+    function pad(num) { return num.toString().padStart(3, '0'); }
+    for (let i = 0; i < 8; i++) {
+      const r = new Image();
+      r.src = `/assets/Bullets/1/bullet${pad(i)}.png`;
+      bulletSprites.right.push(r);
+      const b = new Image();
+      b.src = `/assets/Bullets/2/tile${pad(i)}.png`;
+      bulletSprites.left.push(b);
+    }
+    let bulletFrameTick = 0;
 
     function resizeCanvas(){
       canvas.width = window.innerWidth;
@@ -324,8 +333,11 @@
       ctx.fillStyle = gradRight;
       ctx.fillRect(canvas.width / 2, 0, canvas.width / 2, canvas.height);
       
+      const frame = Math.floor(bulletFrameTick / 5) % 8;
+      bulletFrameTick++;
       data.bullets.forEach(bullet => {
-        ctx.drawImage(bulletSprite, bullet.x - bullet.radius, bullet.y - bullet.radius, bullet.radius * 2, bullet.radius * 2);
+        const img = bulletSprites[bullet.team][frame];
+        if (img) ctx.drawImage(img, bullet.x - bullet.radius, bullet.y - bullet.radius, bullet.radius * 2, bullet.radius * 2);
       });
       
       for (const id in data.players) {


### PR DESCRIPTION
## Summary
- serve `assets/` so images are available
- animate bullets using 8‑frame sprites from `assets/Bullets`
- remove unused bullet.svg and update docs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bd8e532508328aba10721fae77479