### PR TITLE
Fix player spawn and cleanup team list

### DIFF
--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -88,6 +88,7 @@ function initSocket(io) {
       if (!gameState.gameStarted) {
         gameState.gameStarted = true;
         gameState.gameStartTime = Date.now();
+        Object.values(gameState.players).forEach(spawnPlayer);
       }
     });
 

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -25,8 +25,7 @@
       color: #fff;
       max-height: 250px;
       overflow-y: auto;
-      z-index: 10000;
-      z-index: 9998;
+      z-index: 10001;
       text-align: left;
     }
     #blueTeamPopup { left: 20px; border: 2px solid #007BFF; }
@@ -34,19 +33,6 @@
     .teamPopup h4 { margin-bottom: 5px; font-size: 18px; }
     .teamPopup ul { list-style: none; padding: 0; margin: 0; }
     .teamPopup li { font-size: 16px; margin-bottom: 3px; }
-    #playersList h4 {
-      margin-bottom: 5px;
-      font-size: 18px;
-    }
-    #playersList ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-    #playersList li {
-      font-size: 16px;
-      margin-bottom: 3px;
-    }
     #closeModal, #setGameTimeButton {
       color:#fff; background:#f00; border:none; font-size:18px;
       margin-top:10px; padding:8px 12px; border-radius:4px; cursor:pointer;
@@ -136,18 +122,6 @@
       <br>
       <button id="setGameTimeButton">Set Game Time</button>
       <br>
-      <div id="playersList">
-        <div style="display:flex;justify-content:space-between;gap:20px;">
-          <div>
-            <h4>Left Team</h4>
-            <ul id="playersLeftList" class="list-unstyled"></ul>
-          </div>
-          <div>
-            <h4>Right Team</h4>
-            <ul id="playersRightList" class="list-unstyled"></ul>
-          </div>
-        </div>
-      </div>
       <button id="closeModal">Close & Start Game</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- respawn all players when the game starts
- raise team popup z-index and remove duplicate list inside QR modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684be8fb61f88328b2bd9cebe85b728d