### PR TITLE
Fix missing bullet sprite paths

### DIFF
--- a/views/game.ejs
+++ b/views/game.ejs
@@ -166,11 +166,12 @@
     redSprite.src = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%23FF4136' stroke='%23d62d20' stroke-width='4'/></svg>";
     const bulletSprites = { left: [], right: [] };
     for (let i = 32; i < 40; i++) {
+      const idx = String(i).padStart(3, '0');
       const r = new Image();
-      r.src = `/assets/Bullets/bullet${i}.png`;
+      r.src = `/assets/Bullets/bullet${idx}.png`;
       bulletSprites.right.push(r);
       const b = new Image();
-      b.src = `/assets/Bullets/tile${i}.png`;
+      b.src = `/assets/Bullets/tile${idx}.png`;
       bulletSprites.left.push(b);
     }
     let bulletFrameTick = 0;


### PR DESCRIPTION
## Summary
- load bullet sprites using zero-padded filenames

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bed190db08328a564c1dca5694f3e