### PR TITLE
Add shield visuals and health scaling

### DIFF
--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -49,7 +49,15 @@ function startGameLoop(io) {
       if (player.regenRate) {
         player.lives = Math.min(player.maxLives, player.lives + player.regenRate / 60);
       }
-      
+
+      if (player.shieldMax > 0 && player.shield < player.shieldMax) {
+        if (!player.lastShieldRepair) player.lastShieldRepair = now;
+        if (now - player.lastShieldRepair >= 1000) {
+          player.shield++;
+          player.lastShieldRepair = now;
+        }
+      }
+
       if (gameState.gameStarted && now - player.lastShotTime >= player.bulletCooldown) {
         fireBullets(player);
         player.lastShotTime = now;
@@ -80,6 +88,7 @@ function startGameLoop(io) {
           if (Math.sqrt(dx * dx + dy * dy) < bullet.radius + player.radius) {
             if (player.shield > 0) {
               player.shield--;
+              player.lastShieldRepair = now;
             } else {
               player.lives -= bullet.damage;
             }

--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -123,12 +123,15 @@ function initSocket(io) {
         case 'bulletSpeed':
           p.bulletSpeed++;
           break;
-        case 'health':
+        case 'health': {
+          const newLvl = (p.upgrades.health || 0) + 1;
           p.maxLives += 10;
           p.lives += 10;
-          p.radius += 2;
-          p.regenRate = (p.upgrades.health + 1);
+          p.radius *= 1.2;
+          p.speed *= 0.9;
+          p.regenRate = newLvl;
           break;
+        }
       }
 
       p.upgrades[option]++;

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -285,6 +285,13 @@
         const player = data.players[id];
         const img = player.team === 'left' ? blueSprite : redSprite;
         ctx.drawImage(img, player.x - player.radius, player.y - player.radius, player.radius * 2, player.radius * 2);
+        for (let s = 0; s < player.shield; s++) {
+          ctx.beginPath();
+          ctx.strokeStyle = 'rgba(173,216,230,0.6)';
+          ctx.lineWidth = 3;
+          ctx.arc(player.x, player.y, player.radius + 6 + s * 6, 0, Math.PI * 2);
+          ctx.stroke();
+        }
         if (player.name) {
           ctx.font = "14px sans-serif";
           ctx.fillStyle = "#fff";


### PR DESCRIPTION
## Summary
- show shield circles around players
- regenerate shields each second and reset timer when hit
- scale player size and speed with health upgrades

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bfa43022883289893d6ecd93e7643