### PR TITLE
Update player spawn timing and emoji arrow

### DIFF
--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -58,7 +58,10 @@ function initSocket(io) {
         lastShotTime: Date.now()
       };
       gameState.players[socket.id].maxLevel = gameState.levelCap;
-      spawnPlayer(gameState.players[socket.id]);
+      // Spawn the player immediately only if the game has already started
+      if (gameState.gameStarted) {
+        spawnPlayer(gameState.players[socket.id]);
+      }
       socket.emit('playerInfo', gameState.players[socket.id]);
     });
 
@@ -125,7 +128,7 @@ function initSocket(io) {
       const p = gameState.players[playerId];
       if (p && !gameState.gameStarted) {
         p.team = p.team === 'left' ? 'right' : 'left';
-        spawnPlayer(p);
+        // Do not spawn until the game actually starts
       }
     });
 

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -15,6 +15,7 @@
     #qrContainer {
       background:#222; padding:40px; border-radius:8px; text-align:center;
       font-size:20px;
+      height:80vh;
     }
     .teamPopup {
       position: fixed;
@@ -26,7 +27,7 @@
       background: rgba(0,0,0,0.8);
       border-radius: 8px;
       color: #fff;
-      max-height: 250px;
+      height:80vh;
       overflow-y: auto;
       z-index: 10001;
       text-align: left;
@@ -42,8 +43,8 @@
       margin-top:10px; padding:8px 12px; border-radius:4px; cursor:pointer;
     }
     #pauseButton {
-      background:#fff; border:2px solid red; color:#000; font-size:18px;
-      padding:4px 10px; border-radius:4px; cursor:pointer; pointer-events:auto;
+      background:#fff; border:2px solid red; color:#000; font-size:36px;
+      padding:8px 20px; border-radius:4px; cursor:pointer; pointer-events:auto;
     }
     #pauseButton:hover { box-shadow:0 0 10px red; }
     .popup {
@@ -54,8 +55,14 @@
     }
     .popupBtn { margin:20px; padding:12px 24px; font-size:20px; }
     #gameTimeInput {
-      font-size:16px; padding:5px; margin-top:10px;
-      width:80px; text-align:center;
+      font-size:20px; padding:8px; margin-top:10px;
+      width:240px; text-align:center;
+      border-radius:8px;
+    }
+    #maxLevelInput {
+      font-size:20px; padding:8px; margin-top:10px;
+      width:240px; text-align:center;
+      border-radius:8px;
     }
     #overlay {
       position:absolute;
@@ -70,7 +77,7 @@
       position:relative;
       width:100%;
       margin:0 auto;
-      height:20px;
+      height:50px;
       background:#444;
       border:1px solid #fff;
       margin-top:0;
@@ -93,8 +100,8 @@
       width:100%;
       top:0;
       left:0;
-      line-height:20px;
-      font-size:16px;
+      line-height:50px;
+      font-size:24px;
     }
     #scoreContainer {
       margin-top:6px;
@@ -103,10 +110,10 @@
       gap:20px;
     }
     .scoreBox {
-      padding:4px 10px;
+      padding:8px 20px;
       color:#fff;
       border-radius:4px;
-      font-size:20px;
+      font-size:40px;
     }
     .scoreBlue { background:#007BFF; }
     .scoreRed { background:#FF4136; }
@@ -283,11 +290,23 @@
           const li = document.createElement('li');
           li.textContent = p.name || 'Unnamed';
           const arrow = document.createElement('span');
-          arrow.textContent = p.team === 'left' ? ' \u2192' : ' \u2190';
+          // Use emoji arrows to make the action clearer
+          arrow.textContent = p.team === 'left' ? ' ➡️' : ' ⬅️';
           arrow.style.cursor = 'pointer';
           arrow.style.marginLeft = '4px';
           arrow.addEventListener('click', () => {
+            // Immediately move the player to the opposite team table for quick feedback
+            const currentList = p.team === 'left' ? leftEl : rightEl;
+            const targetList = p.team === 'left' ? rightEl : leftEl;
+            p.team = p.team === 'left' ? 'right' : 'left';
+            currentList.removeChild(li);
+            targetList.appendChild(li);
+            arrow.textContent = p.team === 'left' ? ' ➡️' : ' ⬅️';
             socket.emit('switchTeam', p.id);
+            document.querySelector('#blueTeamPopup h4').textContent =
+              `Blue Team (${leftEl.children.length})`;
+            document.querySelector('#redTeamPopup h4').textContent =
+              `Red Team (${rightEl.children.length})`;
           });
           li.appendChild(arrow);
           if (p.team === 'left') { leftEl.appendChild(li); leftCount++; }


### PR DESCRIPTION
## Summary
- players are now spawned only once the game starts
- swap team arrow uses emoji and no longer spawns player when pregame switching
- clicking the arrow immediately moves the player to the other team table
- bigger UI elements (inputs, scores, time bar, pause button)

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c1d14d8b8832888e489ba4bed7dc7