### PR TITLE
Add pre-game demo bots

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 const { getLocalIp, publishService, stopService } = require('./src/services/networkService');
 const { initSocket } = require('./src/services/socketHandler');
-const { startGameLoop, stopGameLoop } = require('./src/services/gameLogic');
+const { startGameLoop, stopGameLoop, createDemoBots } = require('./src/services/gameLogic');
 
 const app = express();
 const server = http.createServer(app);
@@ -34,6 +34,7 @@ require('./src/controllers/mobileController')(app);
 // Initialize Socket.IO and game loop
 initSocket(io);
 startGameLoop(io);
+createDemoBots();
 
 // Start Bonjour service and HTTP server
 publishService(localIp, PORT, hostName);

--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -91,6 +91,12 @@ function initSocket(io) {
 
     socket.on('startGame', () => {
       if (!gameState.gameStarted) {
+        Object.keys(gameState.players).forEach(id => {
+          if (gameState.players[id].isBot) delete gameState.players[id];
+        });
+        gameState.scoreBlue = 0;
+        gameState.scoreRed = 0;
+        gameState.bullets = [];
         gameState.gameStarted = true;
         gameState.gameStartTime = Date.now();
         Object.values(gameState.players).forEach(spawnPlayer);


### PR DESCRIPTION
## Summary
- add demo bots to fill the background while players join
- create and control bots in `gameLogic`
- clear demo bots and reset scores on start
- invoke bot creation from `server.js`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68506db0996483288f5d583a1280b9a0