### PR TITLE
Add pre-game demo bots

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 const { getLocalIp, publishService, stopService } = require('./src/services/networkService');
 const { initSocket } = require('./src/services/socketHandler');
-const { startGameLoop, stopGameLoop } = require('./src/services/gameLogic');
+const { startGameLoop, stopGameLoop, createDemoBots } = require('./src/services/gameLogic');
 
 const app = express();
 const server = http.createServer(app);
@@ -34,6 +34,7 @@ require('./src/controllers/mobileController')(app);
 // Initialize Socket.IO and game loop
 initSocket(io);
 startGameLoop(io);
+createDemoBots();
 
 // Start Bonjour service and HTTP server
 publishService(localIp, PORT, hostName);

--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -91,6 +91,12 @@ function initSocket(io) {
 
     socket.on('startGame', () => {
       if (!gameState.gameStarted) {
+        Object.keys(gameState.players).forEach(id => {
+          if (gameState.players[id].isBot) delete gameState.players[id];
+        });
+        gameState.scoreBlue = 0;
+        gameState.scoreRed = 0;
+        gameState.bullets = [];
         gameState.gameStarted = true;
         gameState.gameStartTime = Date.now();
         Object.values(gameState.players).forEach(spawnPlayer);

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -295,6 +295,7 @@
         rightEl.innerHTML = '';
         let leftCount = 0, rightCount = 0;
         Object.values(data.players).forEach(p => {
+          if (p.isBot) return;
           const li = document.createElement('li');
           const name = document.createElement('span');
           name.textContent = p.name || 'Unnamed';
@@ -350,6 +351,7 @@
       blueList.innerHTML = '';
       redList.innerHTML = '';
       Object.values(data.players).forEach(p => {
+        if (p.isBot) return;
         const li = document.createElement('li');
         li.textContent = p.name || 'Unnamed';
         if (p.team === 'left') blueList.appendChild(li); else redList.appendChild(li);


### PR DESCRIPTION
## Summary
- add demo bots to fill the background while players join
- create and control bots in `gameLogic`
- clear demo bots and reset scores on start
- invoke bot creation from `server.js`
- filter bots from lobby and winner lists

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68506db0996483288f5d583a1280b9a0