### PR TITLE
Fix layout and allow team switching mid game

### DIFF
--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -132,11 +132,14 @@ function initSocket(io) {
 
     socket.on('switchTeam', (playerId) => {
       const p = gameState.players[playerId];
-      if (p && !gameState.gameStarted) {
+      if (p) {
         p.team = p.team === 'left' ? 'right' : 'left';
         // Update colors so the player sees the change immediately
         p.fillColor = TEAM_COLORS[p.team].fill;
         p.borderColor = TEAM_COLORS[p.team].border;
+        if (gameState.gameStarted) {
+          spawnPlayer(p);
+        }
         // Inform the affected player about their new team
         io.to(playerId).emit('playerInfo', p);
 
@@ -159,7 +162,6 @@ function initSocket(io) {
             gameState.gameStartTime &&
             elapsed >= gameState.gameDuration,
         });
-        // Do not spawn until the game actually starts
       }
     });
 

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -53,6 +53,7 @@
     #pauseButton {
       background:#fff; border:2px solid red; color:#000; font-size:36px;
       padding:8px 20px; border-radius:4px; cursor:pointer; pointer-events:auto;
+      position:absolute; right:10px; top:5px; z-index:1;
     }
     #pauseButton:hover { box-shadow:0 0 10px red; }
     .popup {
@@ -90,6 +91,7 @@
       border:1px solid #fff;
       margin-top:0;
       display:flex; align-items:center; justify-content:center;
+      padding-right:120px;
     }
     #timeBar {
       position:absolute;
@@ -105,9 +107,9 @@
     }
     #timeText {
       position:absolute;
-      width:100%;
       top:0;
       left:0;
+      right:120px;
       line-height:50px;
       font-size:24px;
     }


### PR DESCRIPTION
## Summary
- fix layout of pause button and game timer
- allow switching teams even after the game starts
- reposition players when their team changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685073e08548832896dcc1e6c37e779c