### PR TITLE
Add team deathmatch mode

### DIFF
--- a/src/models/gameState.js
+++ b/src/models/gameState.js
@@ -12,6 +12,8 @@ module.exports = {
     pauseTime: null,
     forceGameOver: false,
     gameDuration: 2 * 60 * 1000,  // default 2 minutes in ms
+    maxRounds: 5,
+    currentRound: 0,
     levelCap: 1,
     canvasWidth: 800,
     canvasHeight: 600

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -224,11 +224,11 @@
       </div>
       <br>
       <table id="settingsTable" style="margin:10px auto; text-align:left;">
-        <tr>
+        <tr id="timeRow">
           <td><label for="gameTimeInput">Game Time (minutes):</label></td>
           <td><input type="number" id="gameTimeInput" value="10" min="1" max="10"></td>
         </tr>
-        <tr>
+        <tr id="levelRow">
           <td><label for="maxLevelInput">Max Levels</label></td>
           <td><input type="number" id="maxLevelInput" value="<%= defaultCap %>" min="1" max="<%= maxAllowedCap %>"></td>
         </tr>
@@ -236,10 +236,15 @@
           <td><label for="gameModeSelect">Game Mode</label></td>
           <td>
             <select id="gameModeSelect">
-              <option value="classic">Classic</option>
+              <option value="classic">Casual</option>
               <option value="control">Point Control</option>
+              <option value="tdm">Team Deathmatch</option>
             </select>
           </td>
+        </tr>
+        <tr id="roundRow" style="display:none;">
+          <td><label for="maxRoundsInput">Max Rounds</label></td>
+          <td><input type="number" id="maxRoundsInput" value="5" min="1" max="20"></td>
         </tr>
         <tr>
           <td><label for="botCountInput">Bots Per Team</label></td>
@@ -374,12 +379,27 @@
     botCount.addEventListener('change', () => {
       if (botCheck.checked) updateBots();
     });
+    const modeSelect = document.getElementById('gameModeSelect');
+    function updateModeRows() {
+      const isTdm = modeSelect.value === 'tdm';
+      document.getElementById('timeRow').style.display = isTdm ? 'none' : '';
+      document.getElementById('levelRow').style.display = isTdm ? 'none' : '';
+      document.getElementById('roundRow').style.display = isTdm ? '' : 'none';
+    }
+    modeSelect.addEventListener('change', updateModeRows);
+    updateModeRows();
+
     document.getElementById('closeModal').addEventListener('click', () => {
       const minutes = document.getElementById('gameTimeInput').value;
       const lvl = document.getElementById('maxLevelInput').value;
-      const mode = document.getElementById('gameModeSelect').value;
-      socket.emit('setGameTime', minutes);
-      socket.emit('setMaxLevels', lvl);
+      const mode = modeSelect.value;
+      if (mode !== 'tdm') {
+        socket.emit('setGameTime', minutes);
+        socket.emit('setMaxLevels', lvl);
+      } else {
+        const rounds = document.getElementById('maxRoundsInput').value;
+        socket.emit('setMaxRounds', rounds);
+      }
       socket.emit('setGameMode', mode);
       document.getElementById('qrModal').style.display = 'none';
       document.getElementById('blueTeamPopup').style.display = 'none';

--- a/views/mobile.ejs
+++ b/views/mobile.ejs
@@ -117,6 +117,21 @@
       text-align: center;
     }
 
+    #deadOverlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.8);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+      color: #fff;
+      font-size: 32px;
+    }
+
     /* Responsive adjustments for portrait */
     @media (orientation: portrait) {
       .controller-container {
@@ -137,6 +152,7 @@
     <div style="font-size:48px;">🔄</div>
     <p>This game is played in Landscape</p>
   </div>
+  <div id="deadOverlay">Wait for next round...</div>
   <!-- Pre-game Name Entry Screen -->
   <div id="nameEntry">
     <input type="text" id="playerName" class="form-control" placeholder="Enter your name">
@@ -242,6 +258,11 @@
         myPlayer = data.players[socket.id];
         updateStats();
         updateUpgradeButtons();
+        if (data.mode === 'tdm') {
+          document.getElementById('deadOverlay').style.display = myPlayer.isAlive ? 'none' : 'flex';
+        } else {
+          document.getElementById('deadOverlay').style.display = 'none';
+        }
       }
       latestPlayers = data.players;
       if (document.getElementById('leaderboardPopup').style.display === 'block') {


### PR DESCRIPTION
## Summary
- add TDM round fields to game state
- handle player deaths and rounds in game logic
- expose new socket controls for TDM
- update start screen with max-rounds option
- show 'wait for next round' on mobile when dead

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bf8a61eb88328b87746cb3ec34ba7