### PR TITLE
Fix bot spawn and endGame logic

### DIFF
--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -385,10 +385,14 @@ function spawnPlayer(player) {
   // Reset player's lives and position based on team
   if (!player.maxLives) player.maxLives = 3;
   player.lives = player.maxLives;
-  player.x = player.team === 'left'
-    ? 100
-    : gameState.canvasWidth - 100;
-  player.y = gameState.canvasHeight / 2;
+  const margin = 50;
+  const half = gameState.canvasWidth / 2;
+  if (player.team === 'left') {
+    player.x = Math.random() * (half - margin * 2) + margin;
+  } else {
+    player.x = Math.random() * (half - margin * 2) + half + margin;
+  }
+  player.y = Math.random() * (gameState.canvasHeight - margin * 2) + margin;
   player.lastShotTime = Date.now();
   if (player.shieldMax > 0) {
     player.shield = player.shieldMax;

--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -182,6 +182,8 @@ function initSocket(io) {
     socket.on('endGame', () => {
       gameState.gameStarted = false;
       gameState.forceGameOver = true;
+      gameState.gamePaused = false;
+      gameState.pauseTime = null;
     });
 
     socket.on('restartGame', () => {

--- a/test/endGame.test.js
+++ b/test/endGame.test.js
@@ -1,0 +1,28 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const events = require('events');
+
+const gameState = require('../src/models/gameState');
+const { initSocket } = require('../src/services/socketHandler');
+
+function setup() {
+  const io = new events.EventEmitter();
+  io.to = () => ({ emit: () => {} });
+  io.emit = () => {};
+  let connectionCb;
+  io.on = (ev, cb) => { if (ev === 'connection') connectionCb = cb; };
+  initSocket(io);
+  const socket = new events.EventEmitter();
+  socket.id = 'testsocket';
+  connectionCb(socket);
+  return socket;
+}
+
+test('endGame clears pause state', () => {
+  const socket = setup();
+  gameState.gamePaused = true;
+  gameState.pauseTime = Date.now();
+  socket.emit('endGame');
+  assert.strictEqual(gameState.gamePaused, false);
+  assert.strictEqual(gameState.pauseTime, null);
+});

--- a/test/gameLogic.test.js
+++ b/test/gameLogic.test.js
@@ -7,13 +7,13 @@ const { spawnPlayer } = require('../src/services/gameLogic');
 test('spawnPlayer positions players based on team', () => {
   const left = { team: 'left', maxLives: 3 };
   spawnPlayer(left);
-  assert.strictEqual(left.x, 100);
-  assert.strictEqual(left.y, gameState.canvasHeight / 2);
+  assert(left.x >= 50 && left.x <= gameState.canvasWidth / 2 - 50);
+  assert(left.y >= 50 && left.y <= gameState.canvasHeight - 50);
   assert.strictEqual(left.lives, left.maxLives);
 
   const right = { team: 'right', maxLives: 5 };
   spawnPlayer(right);
-  assert.strictEqual(right.x, gameState.canvasWidth - 100);
-  assert.strictEqual(right.y, gameState.canvasHeight / 2);
+  assert(right.x >= gameState.canvasWidth / 2 + 50 && right.x <= gameState.canvasWidth - 50);
+  assert(right.y >= 50 && right.y <= gameState.canvasHeight - 50);
   assert.strictEqual(right.lives, right.maxLives);
 });


### PR DESCRIPTION
## Summary
- randomize bot spawn location when spawned
- ensure End Game button unpauses game so final screen shows
- add unit test for endGame handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d08ffaca08328a94c583745727ba8