### PR TITLE
Limit kill messages and disable early shots

### DIFF
--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -130,7 +130,7 @@ function startGameLoop(io) {
         }
       }
 
-      if ((gameState.gameStarted || player.isBot) &&
+      if (gameState.gameStarted &&
           now - player.lastShotTime >= player.bulletCooldown) {
         fireBullets(player);
         player.lastShotTime = now;

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -320,6 +320,10 @@
       el.className = 'killMessage';
       el.textContent = text;
       container.appendChild(el);
+      // limit to 5 messages
+      while (container.children.length > 5) {
+        container.firstElementChild.remove();
+      }
       setTimeout(() => {
         el.style.opacity = '0';
         setTimeout(() => el.remove(), 2000);


### PR DESCRIPTION
## Summary
- disallow player bullets until the round has started
- keep only the newest five kill messages on screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874a5ed17048328ab3cbcf6db786fe6