### PR TITLE
Fix restart and end game functionality

### DIFF
--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -198,7 +198,27 @@ function initSocket(io) {
       gameState.gameStartTime = null;
       gameState.forceGameOver = false;
       gameState.currentRound = 0;
-      Object.values(gameState.players).forEach(spawnPlayer);
+      Object.values(gameState.players).forEach(p => {
+        p.level = 1;
+        p.exp = 0;
+        p.upgradePoints = 0;
+        p.upgrades = {};
+        p.bulletDamage = 1;
+        p.bulletCooldown = 1000;
+        p.bulletSpeed = 8;
+        p.regenRate = 0;
+        p.maxLives = 3;
+        p.lives = 3;
+        p.radius = 20;
+        p.shield = 0;
+        p.shieldMax = 0;
+        p.kills = 0;
+        p.deaths = 0;
+        p.assists = 0;
+        p.lastDamagedBy = null;
+        p.maxLevel = gameState.levelCap;
+        spawnPlayer(p);
+      });
     });
 
     socket.on('setTeam', ({ playerId, team }) => {

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -366,14 +366,14 @@
       if (!data.gameStarted) {
         updateTeamLists(data);
       }
-      drawGame(data);
-      if (data.gameOver) {
+      if (!data.gameOver) {
+        drawGame(data);
+      } else {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
         if (!winnerShown) {
           winnerShown = true;
           showWinner(data);
         }
-      } else {
-        winnerShown = false;
       }
     });
 


### PR DESCRIPTION
## Summary
- reset player stats when restarting
- clear canvas and hide players after game over to show end screen cleanly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874d7d51e388328a48ea90c14dbe776