### PR TITLE
Fix end game flow and bot updates

### DIFF
--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -142,6 +142,27 @@ function initSocket(io) {
     socket.on('addBot', (team) => {
       if (team === 'left' || team === 'right') {
         createBot(team);
+        const now = Date.now();
+        const elapsed = gameState.gameStartTime ? now - gameState.gameStartTime : 0;
+        io.emit('gameState', {
+          players: gameState.players,
+          bullets: gameState.bullets,
+          scoreBlue: gameState.scoreBlue,
+          scoreRed: gameState.scoreRed,
+          mode: gameState.mode,
+          currentRound: gameState.currentRound,
+          maxRounds: gameState.maxRounds,
+          gameTimer: gameState.gameStarted
+            ? Math.max(0, Math.floor((gameState.gameDuration - elapsed) / 1000))
+            : 0,
+          gameDuration: Math.floor(gameState.gameDuration / 1000),
+          gamePaused: gameState.gamePaused,
+          gameStarted: gameState.gameStarted,
+          gameOver:
+            !gameState.gameStarted &&
+            gameState.gameStartTime &&
+            elapsed >= gameState.gameDuration,
+        });
       }
     });
 
@@ -188,6 +209,7 @@ function initSocket(io) {
       if (gameState.gameStarted) {
         gameState.gameStarted = false;
         gameState.gameActive = false;
+        gameState.gamePaused = false;
         gameState.forceGameOver = true;
       }
     });


### PR DESCRIPTION
## Summary
- ensure `endGame` exits pause state so the end screen shows
- broadcast updated game state immediately after adding a bot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874dc23312c8328ba4b8bd570f475a2