### PR TITLE
Fix bot management

### DIFF
--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -264,6 +264,27 @@ function initSocket(io) {
       if (gameState.players[playerId]) {
         io.to(playerId).emit('kicked');
         delete gameState.players[playerId];
+        const now = Date.now();
+        const elapsed = gameState.gameStartTime ? now - gameState.gameStartTime : 0;
+        io.emit('gameState', {
+          players: gameState.players,
+          bullets: gameState.bullets,
+          scoreBlue: gameState.scoreBlue,
+          scoreRed: gameState.scoreRed,
+          mode: gameState.mode,
+          currentRound: gameState.currentRound,
+          maxRounds: gameState.maxRounds,
+          gameTimer: gameState.gameStarted
+            ? Math.max(0, Math.floor((gameState.gameDuration - elapsed) / 1000))
+            : 0,
+          gameDuration: Math.floor(gameState.gameDuration / 1000),
+          gamePaused: gameState.gamePaused,
+          gameStarted: gameState.gameStarted,
+          gameOver:
+            !gameState.gameStarted &&
+            gameState.gameStartTime &&
+            elapsed >= gameState.gameDuration,
+        });
       }
     });
 

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -460,12 +460,10 @@
         const name = document.createElement('span');
         name.className = 'playerName';
         name.textContent = p.name || 'Unnamed';
-        if (!p.isBot) {
-          name.draggable = true;
-          name.addEventListener('dragstart', (e) => {
-            e.dataTransfer.setData('playerId', p.id);
-          });
-        }
+        name.draggable = true;
+        name.addEventListener('dragstart', (e) => {
+          e.dataTransfer.setData('playerId', p.id);
+        });
         const remove = document.createElement('span');
         remove.textContent = '❌';
         remove.className = 'removeBtn';


### PR DESCRIPTION
## Summary
- allow bots to be drag-and-dropped between teams
- broadcast updated state after removing a player or bot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874eedac2388328b556b527f106ab99