### PR TITLE
Add exit option for endgame screen

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,6 +36,13 @@ require('./src/controllers/pcController')(app);
 initSocket(io);
 startGameLoop(io);
 
+// Endpoint to gracefully shutdown the game
+app.post('/exit', (req, res) => {
+  res.send('Shutting down');
+  // Give the response time to be sent before closing everything
+  setTimeout(shutdown, 100);
+});
+
 // Start Bonjour service and HTTP server
 publishService(localIp, PORT, hostName);
 

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -152,7 +152,7 @@
     <h2 id="winnerTitle"></h2>
     <div id="winnerPopupInner" class="mt-2"><div><h3 style="color:var(--blue-team)">Blue Team</h3><ul id="winnerBlue" class="list-unstyled"></ul></div><div><h3 style="color:var(--red-team)">Red Team</h3><ul id="winnerRed" class="list-unstyled"></ul></div></div>
     <div class="mt-2"><span id="timer">Time: 0s</span> | <span id="scoreboard">Blue: 0 - Red: 0</span></div>
-    <div class="mt-3"><button id="closeWinner" class="popupBtn">Close</button><button id="restartFinal" class="popupBtn">Restart</button></div>
+    <div class="mt-3"><button id="exitButton" class="popupBtn">Exit</button><button id="restartFinal" class="popupBtn">Restart</button></div>
   </div>
 
   <!-- CANVAS + FEEDS -->
@@ -291,7 +291,8 @@
       socket.emit('startGame');
     });
 
-    document.getElementById('closeWinner').addEventListener('click', () => {
+    document.getElementById('exitButton').addEventListener('click', () => {
+      fetch('/exit', { method: 'POST' });
       document.getElementById('winnerPopup').style.display = 'none';
       document.getElementById('overlay').classList.remove('blur');
       document.getElementById('gameCanvas').classList.remove('blur');


### PR DESCRIPTION
## Summary
- add `/exit` endpoint for graceful server shutdown
- rename winner popup button to `Exit`
- invoke new exit route when clicking the button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874ef260470832884786ba79c5dfecc