### PR TITLE
Add TDM round messages and random spawns

### DIFF
--- a/test/gameLogic.test.js
+++ b/test/gameLogic.test.js
@@ -4,7 +4,8 @@ const { test } = require('node:test');
 const gameState = require('../src/models/gameState');
 const { spawnPlayer } = require('../src/services/gameLogic');
 
-test('spawnPlayer positions players based on team', () => {
+test('spawnPlayer positions players based on team in classic mode', () => {
+  gameState.mode = 'classic';
   const left = { team: 'left', maxLives: 3 };
   spawnPlayer(left);
   assert.strictEqual(left.x, 100);
@@ -16,4 +17,12 @@ test('spawnPlayer positions players based on team', () => {
   assert.strictEqual(right.x, gameState.canvasWidth - 100);
   assert.strictEqual(right.y, gameState.canvasHeight / 2);
   assert.strictEqual(right.lives, right.maxLives);
+});
+
+test('spawnPlayer uses random positions in tdm mode', () => {
+  gameState.mode = 'tdm';
+  const p = { team: 'left', maxLives: 3 };
+  spawnPlayer(p);
+  assert.ok(p.x >= 50 && p.x <= gameState.canvasWidth / 2 - 50);
+  assert.ok(p.y >= 50 && p.y <= gameState.canvasHeight - 50);
 });

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -91,6 +91,13 @@
     .killMessage{padding:.5rem 1rem;background:rgba(0,0,0,.6);border-radius:6px;font-size:1.3rem;opacity:1;transition:opacity 2s;}
     #killFeed{position:fixed;top:60px;right:10px;width:260px;display:flex;flex-direction:column;align-items:flex-end;gap:.25rem;opacity:.7;pointer-events:none;font-size:.9rem;z-index:10002;}
     .killFeedItem{background:rgba(0,0,0,.5);padding:.25rem .5rem;border-radius:4px;}
+
+    /* Round / winner titles */
+    #roundTitle{
+      position:fixed;top:40%;left:50%;transform:translate(-50%,-50%);
+      font-size:3rem;color:#fff;pointer-events:none;opacity:0;
+      transition:opacity .5s;z-index:10004;text-shadow:0 0 10px #000;
+    }
   </style>
 </head>
 <body>
@@ -159,6 +166,7 @@
   <canvas id="gameCanvas"></canvas>
   <div id="killMessages"></div>
   <div id="killFeed"></div>
+  <div id="roundTitle"></div>
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
@@ -263,7 +271,7 @@
     const modeSelect = document.getElementById('gameModeSelect');
     function updateModeRows() {
       const isTdm = modeSelect.value === 'tdm';
-      document.getElementById('timeRow').style.display = isTdm ? 'none' : '';
+      document.querySelector('#timeRow label').textContent = isTdm ? 'Round Time' : 'Game Time';
       document.getElementById('levelRow').style.display = isTdm ? 'none' : '';
       document.getElementById('roundRow').style.display = isTdm ? '' : 'none';
     }
@@ -281,6 +289,7 @@
         socket.emit('setMaxLevels', lvl);
       } else {
         const rounds = document.getElementById('maxRoundsInput').value;
+        socket.emit('setGameTime', minutes); // round duration
         socket.emit('setMaxRounds', rounds);
       }
       socket.emit('setGameMode', mode);
@@ -362,6 +371,13 @@
       });
     }
 
+    function showRoundTitle(text){
+      const el = document.getElementById('roundTitle');
+      el.textContent = text;
+      el.style.opacity = '1';
+      setTimeout(()=>{ el.style.opacity = '0'; }, 2000);
+    }
+
     let winnerShown = false;
 
     socket.on('gameState', (data) => {
@@ -409,6 +425,17 @@
     socket.on('regenPopup', ({ x, y, amount, type }) => {
       const color = type === 'shield' ? '#00b3ff' : '#00ff80';           // blue or green
       spawnFloatingText({ x, y, text: `+${amount}`, color });
+    });
+
+    socket.on('roundStart', ({ round }) => {
+      showRoundTitle('Round ' + round);
+    });
+
+    socket.on('roundEnd', ({ winner }) => {
+      let text = 'Draw';
+      if (winner === 'left') text = 'Blue Wins';
+      else if (winner === 'right') text = 'Red Wins';
+      showRoundTitle(text);
     });
 
     function showWinner(data) {
@@ -516,8 +543,11 @@
           3A.  Draw the ship sprite
         ---------------------------------------------------------- */
         const sprite = p.team === 'left' ? blueSprite : redSprite;
+        const faded = data.mode==='tdm' && !p.isAlive;
+        if (faded) ctx.globalAlpha = 0.35;
         ctx.drawImage(sprite, p.x - p.radius, p.y - p.radius,
                       p.radius * 2, p.radius * 2);
+        if (faded) { ctx.globalAlpha = 1; continue; }
 
         /* ----------------------------------------------------------
           3B.  Shield + health bars

--- a/views/pc.ejs
+++ b/views/pc.ejs
@@ -79,6 +79,12 @@
     #killFeed{position:fixed;top:60px;right:10px;width:260px;display:flex;flex-direction:column;align-items:flex-end;gap:.25rem;font-size:.9rem;opacity:.7;pointer-events:none;z-index:1002;}
     .killFeedItem{background:rgba(0,0,0,.5);padding:.25rem .5rem;border-radius:4px;}
 
+    #roundTitle{
+      position:fixed;top:40%;left:50%;transform:translate(-50%,-50%);
+      font-size:3rem;color:#fff;pointer-events:none;opacity:0;
+      transition:opacity .5s;z-index:1004;text-shadow:0 0 10px #000;
+    }
+
     /* Team aura around the screen */
     #teamAura{
       position:fixed;
@@ -124,6 +130,7 @@
   <!-- FEEDS -->
   <div id="killMessages"></div>
   <div id="killFeed"></div>
+  <div id="roundTitle"></div>
 
   <!-- Spectator + Join Elements -->
   <div id="spectatorMsg">
@@ -192,8 +199,15 @@ let currentTeam = null;
       ctx.fillStyle = f.color;
       ctx.textAlign = 'center';
       ctx.fillText(f.text, f.x, f.y - age * 0.05);   // drift ↑
-      ctx.globalAlpha = 1;
-    }
+    ctx.globalAlpha = 1;
+  }
+
+  function showRoundTitle(text){
+    const el = document.getElementById('roundTitle');
+    el.textContent = text;
+    el.style.opacity = '1';
+    setTimeout(()=>{ el.style.opacity = '0'; }, 2000);
+  }
   }
 
   /* ========================================================
@@ -205,6 +219,13 @@ let currentTeam = null;
   socket.on('regenPopup',  ({ x, y, amount, type }) =>
     spawnFloat({ x, y, text: `+${amount}`, color: type === 'shield' ? '#00b3ff' : '#00ff80' })
   );
+  socket.on('roundStart', ({ round }) => showRoundTitle('Round ' + round));
+  socket.on('roundEnd', ({ winner }) => {
+    let t = 'Draw';
+    if (winner === 'left') t = 'Blue Wins';
+    else if (winner === 'right') t = 'Red Wins';
+    showRoundTitle(t);
+  });
 
   /* ========================================================
     4.  INPUT – WASD AIM
@@ -262,11 +283,14 @@ let currentTeam = null;
   /* ========================================================
     6.  DRAW HELPERS
   ======================================================== */
-  function drawPlayers(players) {
+  function drawPlayers(players, mode) {
     for (const id in players) {
       const p = players[id];
       const spr = p.team === 'left' ? blueShip : redShip;
+      const faded = mode==='tdm' && !p.isAlive;
+      if (faded) ctx.globalAlpha = 0.35;
       ctx.drawImage(spr, p.x - p.radius, p.y - p.radius, p.radius * 2, p.radius * 2);
+      if (faded) { ctx.globalAlpha = 1; continue; }
 
       /* bars */
       const bw = p.radius * 2,
@@ -312,7 +336,7 @@ let currentTeam = null;
     });
 
     // players & pop-ups
-    drawPlayers(state.players);
+    drawPlayers(state.players, state.mode);
     drawFloatTexts();
 
     updateAura(state.players[socket.id]?.team);


### PR DESCRIPTION
## Summary
- make TDM spawns random and keep corpses intangible on death
- emit round start/end events from the server
- show fading round titles and winners on clients
- adjust start screen to configure round time and max rounds
- update tests for new spawn behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f0de28108328b525c99fda9cde1f