### PR TITLE
Fix TDM rounds and bot AI

### DIFF
--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -83,8 +83,21 @@ function startGameLoop(io) {
     // Update each player's position and stats
     Object.values(gameState.players).forEach(player => {
       if (gameState.mode === 'tdm' && !player.isAlive) return;
-      if (!gameState.gameStarted && player.isBot) {
-        if (!player.nextChange || now > player.nextChange) {
+      if (player.isBot) {
+        if (gameState.gameStarted) {
+          const enemies = Object.values(gameState.players)
+            .filter(p => p.team !== player.team && (gameState.mode !== 'tdm' || p.isAlive));
+          if (enemies.length > 0) {
+            const target = enemies.reduce((closest, p) => {
+              const dx = p.x - player.x;
+              const dy = p.y - player.y;
+              const distSq = dx * dx + dy * dy;
+              if (!closest || distSq < closest.distSq) return { p, distSq };
+              return closest;
+            }, null).p;
+            player.angle = Math.atan2(target.y - player.y, target.x - player.x) * 180 / Math.PI;
+          }
+        } else if (!player.nextChange || now > player.nextChange) {
           player.angle = Math.random() * 360;
           player.nextChange = now + 1000 + Math.random() * 2000;
         }
@@ -406,7 +419,19 @@ function endTdmRound(winner) {
   if (gameState.currentRound >= gameState.maxRounds) {
     gameState.forceGameOver = true;
   } else {
-    setTimeout(startTdmRound, 3000);
+    if (ioInstance) {
+      let count = 3;
+      const interval = setInterval(() => {
+        ioInstance.emit('roundCountdown', { count });
+        count--;
+        if (count === 0) {
+          clearInterval(interval);
+          startTdmRound();
+        }
+      }, 1000);
+    } else {
+      setTimeout(startTdmRound, 3000);
+    }
   }
 }
 

--- a/views/game.ejs
+++ b/views/game.ejs
@@ -98,6 +98,11 @@
       font-size:3rem;color:#fff;pointer-events:none;opacity:0;
       transition:opacity .5s;z-index:10004;text-shadow:0 0 10px #000;
     }
+    #countdown{
+      position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);
+      font-size:5rem;color:#fff;pointer-events:none;opacity:0;
+      transition:opacity .5s;z-index:10005;text-shadow:0 0 10px #000;
+    }
   </style>
 </head>
 <body>
@@ -167,6 +172,7 @@
   <div id="killMessages"></div>
   <div id="killFeed"></div>
   <div id="roundTitle"></div>
+  <div id="countdown"></div>
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
@@ -379,6 +385,13 @@
       setTimeout(()=>{ el.style.opacity = '0'; }, 2000);
     }
 
+    function showCountdown(num){
+      const el = document.getElementById('countdown');
+      el.textContent = num;
+      el.style.opacity = '1';
+      setTimeout(()=>{ el.style.opacity = '0'; }, 750);
+    }
+
     let winnerShown = false;
 
     socket.on('gameState', (data) => {
@@ -430,6 +443,10 @@
 
     socket.on('roundStart', ({ round }) => {
       showRoundTitle('Round ' + round);
+    });
+
+    socket.on('roundCountdown', ({ count }) => {
+      showCountdown(count);
     });
 
     socket.on('roundEnd', ({ winner }) => {


### PR DESCRIPTION
## Summary
- add bot targeting logic so bots pursue surviving enemies
- emit `roundCountdown` on server between TDM rounds
- display countdown numbers in game view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f46d966c83288e8962b46aea6cad