### PR TITLE
Add settings popup with animation, name size and damage options

### DIFF
--- a/views/game.ejs
+++ b/views/game.ejs
@@ -43,7 +43,9 @@
     #qrContainer{background:rgba(0,0,0,.55);backdrop-filter:blur(6px);border:2px solid var(--neutral);border-radius:12px;padding:2rem 2.5rem;max-width:clamp(340px,50vw,650px);max-height:90vh;overflow-y:auto;text-align:center;}
     #qrContainer h2{font-size:1.8rem;margin-bottom:1rem;}
 
-    #lowAnimOption{position:absolute;bottom:10px;left:10px;}
+
+    #settingsPopup .form-check,
+    #settingsPopup .form-select{margin-bottom:.75rem;}
 
     #legend ul{margin:.25rem 0 0 1.25rem;}
     #legend li{margin-bottom:4px;font-size:.95rem;}
@@ -148,10 +150,7 @@
       <tr id="roundRow" style="display:none;"><td><label for="maxRoundsInput">Max Rounds</label></td><td><input type="number" id="maxRoundsInput" value="5" min="1" max="20" class="form-control form-control-sm"></td></tr>
     </table>
     <button id="closeModal" class="btn btn-light mt-3"><i class="bi bi-play-fill"></i> Start Game</button>
-    <div id="lowAnimOption" class="form-check">
-      <label for="lowAnimCheck" class="form-check-label me-2">Reduce animations?</label>
-      <input type="checkbox" id="lowAnimCheck" class="form-check-input">
-    </div>
+    <button id="openSettings" class="btn btn-secondary mt-2">Settings</button>
   </div></div>
 
   <!-- HUD -->
@@ -165,7 +164,7 @@
   </div>
 
   <!-- GENERIC POPUPS -->
-  <div id="pausePopup" class="popup"><button id="continueButton" class="popupBtn">Continue</button><button id="restartButton" class="popupBtn">Restart</button><button id="endButton" class="popupBtn">End Game</button></div>
+  <div id="pausePopup" class="popup"><button id="continueButton" class="popupBtn">Continue</button><button id="restartButton" class="popupBtn">Restart</button><button id="endButton" class="popupBtn">End Game</button><button id="openSettingsPause" class="popupBtn">Settings</button></div>
   <div id="leaderboardPopup" class="popup"><h2>Leaderboard</h2><div><div><h3 style="color:var(--blue-team)">Blue Fleet</h3><table id="lbBlue" class="table table-dark table-sm"></table></div><div><h3 style="color:var(--red-team)">Red Fleet</h3><table id="lbRed" class="table table-dark table-sm"></table></div></div></div>
 
   <div id="winnerPopup" class="popup" style="max-width:950px;margin:auto;">
@@ -173,6 +172,27 @@
     <div id="winnerPopupInner" class="mt-2"><div><h3 style="color:var(--blue-team)">Blue Team</h3><ul id="winnerBlue" class="list-unstyled"></ul></div><div><h3 style="color:var(--red-team)">Red Team</h3><ul id="winnerRed" class="list-unstyled"></ul></div></div>
     <div class="mt-2"><span id="timer">Time: 0s</span> | <span id="scoreboard">Blue: 0 - Red: 0</span></div>
     <div class="mt-3"><button id="exitButton" class="popupBtn">Exit</button><button id="restartFinal" class="popupBtn">Restart</button></div>
+  </div>
+
+  <div id="settingsPopup" class="popup">
+    <h2>Settings</h2>
+    <div class="form-check">
+      <input type="checkbox" id="settingsLowAnim" class="form-check-input">
+      <label for="settingsLowAnim" class="form-check-label ms-2">Reduce animations?</label>
+    </div>
+    <div>
+      <label for="nameSizeSelect" class="form-label">Name Size</label>
+      <select id="nameSizeSelect" class="form-select form-select-sm">
+        <option value="12">Small</option>
+        <option value="16" selected>Medium</option>
+        <option value="20">Large</option>
+      </select>
+    </div>
+    <div class="form-check">
+      <input type="checkbox" id="damagePopupCheck" class="form-check-input" checked>
+      <label for="damagePopupCheck" class="form-check-label ms-2">Damage Popups</label>
+    </div>
+    <button id="closeSettings" class="btn btn-light mt-3">Back</button>
   </div>
 
   <!-- CANVAS + FEEDS -->
@@ -233,11 +253,28 @@
     }
     let bulletFrameTick = 0;
     let useSimpleBullets = false;
-    const lowAnimCheck = document.getElementById('lowAnimCheck');
+    let showDamagePopups = true;
+    let nameSize = 16;
+    let settingsReturn = null;
+    const lowAnimCheck = document.getElementById('settingsLowAnim');
+    const damageCheck = document.getElementById('damagePopupCheck');
+    const nameSizeSelect = document.getElementById('nameSizeSelect');
     if(lowAnimCheck){
       useSimpleBullets = lowAnimCheck.checked;
       lowAnimCheck.addEventListener('change',()=>{
         useSimpleBullets = lowAnimCheck.checked;
+      });
+    }
+    if(damageCheck){
+      showDamagePopups = damageCheck.checked;
+      damageCheck.addEventListener('change',()=>{
+        showDamagePopups = damageCheck.checked;
+      });
+    }
+    if(nameSizeSelect){
+      nameSize = parseInt(nameSizeSelect.value);
+      nameSizeSelect.addEventListener('change',()=>{
+        nameSize = parseInt(nameSizeSelect.value);
       });
     }
     let gradLeft, gradRight;
@@ -329,6 +366,32 @@
       document.getElementById('redTeamPopup').style.display = 'none';
       document.getElementById('winnerPopup').style.display = 'none';
       socket.emit('startGame');
+    });
+
+    document.getElementById('openSettings').addEventListener('click', () => {
+      settingsReturn = 'start';
+      document.getElementById('qrModal').style.display = 'none';
+      document.getElementById('blueTeamPopup').style.display = 'none';
+      document.getElementById('redTeamPopup').style.display = 'none';
+      document.getElementById('settingsPopup').style.display = 'flex';
+    });
+
+    document.getElementById('openSettingsPause').addEventListener('click', () => {
+      settingsReturn = 'pause';
+      document.getElementById('pausePopup').style.display = 'none';
+      document.getElementById('settingsPopup').style.display = 'flex';
+    });
+
+    document.getElementById('closeSettings').addEventListener('click', () => {
+      document.getElementById('settingsPopup').style.display = 'none';
+      if(settingsReturn === 'start'){
+        document.getElementById('qrModal').style.display = 'flex';
+        document.getElementById('blueTeamPopup').style.display = 'block';
+        document.getElementById('redTeamPopup').style.display = 'block';
+      }else if(settingsReturn === 'pause'){
+        document.getElementById('pausePopup').style.display = 'flex';
+      }
+      settingsReturn = null;
     });
 
     document.getElementById('exitButton').addEventListener('click', () => {
@@ -458,7 +521,9 @@
     });
 
     socket.on('damagePopup', ({ x, y, amount }) => {
-      spawnFloatingText({ x, y, text: `-${amount}`, color: '#ff273d' }); // red
+      if(showDamagePopups){
+        spawnFloatingText({ x, y, text: `-${amount}`, color: '#ff273d' });
+      }
     });
 
     socket.on('regenPopup', ({ x, y, amount, type }) => {
@@ -631,7 +696,7 @@
         /* ----------------------------------------------------------
           3C.  Player name & stats
         ---------------------------------------------------------- */
-        ctx.font = '16px Orbitron, sans-serif';
+        ctx.font = nameSize + 'px Orbitron, sans-serif';
         ctx.fillStyle = '#ffffff';
         ctx.textAlign = 'center';
         ctx.fillText(p.name || 'Anon', p.x, barY - 8);


### PR DESCRIPTION
## Summary
- replace `Reduce animations` option with a new Settings popup
- open the settings popup from the start screen and pause menu
- add name size and damage popup toggles
- use chosen name size in rendering and hide damage popups when disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875fba5d8dc8328af7ce0e23d12bd2d