### PR TITLE
Fix team popup interactions

### DIFF
--- a/views/game.ejs
+++ b/views/game.ejs
@@ -328,6 +328,7 @@
         nameSize = parseInt(nameSizeSelect.value);
       });
     }
+    let lastPlayerListSig = '';
     let gradLeft, gradRight;
 
     let killTemplates = ["{name2} killed {name1}"];
@@ -665,6 +666,12 @@
     }
 
     function updateTeamLists(data) {
+      const sig = Object.values(data.players)
+        .map(p => `${p.id}|${p.team}|${p.name}|${p.isBot}|${p.behavior}`)
+        .sort()
+        .join(';');
+      if (sig === lastPlayerListSig) return;
+      lastPlayerListSig = sig;
       const leftEl = document.getElementById('playersLeft');
       const rightEl = document.getElementById('playersRight');
       leftEl.innerHTML = '';


### PR DESCRIPTION
## Summary
- stop frequently rebuilding team popups
- add signature check to update team lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687614014b148328b6ccd2c8b57c4b3e