### PR TITLE
Add home page and multi-game routing

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,8 +24,14 @@ app.use('/assets', express.static(path.join(__dirname, 'assets')));
 const PORT = process.env.PORT || 3000;
 const localIp = getLocalIp();
 const hostName = 'space-battle-pong.local';
-const joinURL = `http://${localIp}:${PORT}/controller`;
-app.locals.joinURL = joinURL;
+const baseURL = `http://${localIp}:${PORT}`;
+app.locals.baseURL = baseURL;
+app.locals.joinURL = `${baseURL}/space-battle/controller`;
+
+// Home page
+app.get('/', (req, res) => {
+  res.render('home');
+});
 
 // Register routes
 require('./src/controllers/gameController')(app);
@@ -49,7 +55,7 @@ publishService(localIp, PORT, hostName);
 server.listen(PORT, () => {
   console.log(`Server running at http://${localIp}:${PORT}`);
   console.log(`Broadcast address: http://${hostName}:${PORT}`);
-  console.log(`PC controller URL: http://${localIp}:${PORT}/pc`);
+  console.log(`PC controller URL: http://${localIp}:${PORT}/space-battle/pc`);
 });
 
 // Graceful shutdown function

--- a/src/controllers/gameController.js
+++ b/src/controllers/gameController.js
@@ -4,8 +4,9 @@ const { TOTAL_UPGRADE_LEVELS, MAX_LEVEL_CAP, upgradeBreakdown } = require('../mo
 const { behaviors } = require('../botBehaviors');
 
 module.exports = (app) => {
-  app.get('/', (req, res) => {
-    res.render('game', {
+  function renderGame(res, view, controllerPath) {
+    app.locals.joinURL = `${app.locals.baseURL}${controllerPath}`;
+    res.render(view, {
       joinURL: app.locals.joinURL,
       totalUpgrades: TOTAL_UPGRADE_LEVELS,
       maxAllowedCap: MAX_LEVEL_CAP,
@@ -13,5 +14,21 @@ module.exports = (app) => {
       upgradeBreakdown,
       botBehaviors: Object.keys(behaviors)
     });
+  }
+
+  app.get('/space-battle', (req, res) => {
+    renderGame(res, 'game', '/space-battle/controller');
+  });
+
+  app.get('/game2', (req, res) => {
+    renderGame(res, 'game2/game', '/game2/controller');
+  });
+
+  app.get('/game3', (req, res) => {
+    renderGame(res, 'game3/game', '/game3/controller');
+  });
+
+  app.get('/game4', (req, res) => {
+    renderGame(res, 'game4/game', '/game4/controller');
   });
 };

--- a/src/controllers/mobileController.js
+++ b/src/controllers/mobileController.js
@@ -1,7 +1,18 @@
 // src/controllers/mobileController.js
 module.exports = (app) => {
-  app.get('/controller', (req, res) => {
-    // Render the "mobile" view (mobile.ejs). You can pass additional variables if needed.
+  app.get('/space-battle/controller', (req, res) => {
     res.render('mobile');
+  });
+
+  app.get('/game2/controller', (req, res) => {
+    res.render('game2/mobile');
+  });
+
+  app.get('/game3/controller', (req, res) => {
+    res.render('game3/mobile');
+  });
+
+  app.get('/game4/controller', (req, res) => {
+    res.render('game4/mobile');
   });
 };

--- a/src/controllers/pcController.js
+++ b/src/controllers/pcController.js
@@ -1,6 +1,18 @@
 // src/controllers/pcController.js
 module.exports = (app) => {
-  app.get('/pc', (req, res) => {
+  app.get('/space-battle/pc', (req, res) => {
     res.render('pc');
+  });
+
+  app.get('/game2/pc', (req, res) => {
+    res.render('game2/pc');
+  });
+
+  app.get('/game3/pc', (req, res) => {
+    res.render('game3/pc');
+  });
+
+  app.get('/game4/pc', (req, res) => {
+    res.render('game4/pc');
   });
 };

--- a/views/game2/game.ejs
+++ b/views/game2/game.ejs
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game 2 – Under Construction</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <style>
+    :root {
+      --blue-team:#00b3ff;
+      --red-team:#ff273d;
+      --neutral:#ffffff;
+      --bg-dark:#0a0d13;
+      --bg-mid:#142134;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    html,body{height:100%;width:100%;overflow:hidden;font-family:'Orbitron',sans-serif;color:var(--neutral);}
+    body{background:radial-gradient(ellipse at bottom,var(--bg-mid) 0%,var(--bg-dark) 100%);}
+    body::before{content:"";position:fixed;inset:0;width:300%;height:300%;background:url("https://raw.githubusercontent.com/Kieran-Brown/assets/main/stars_2.png") repeat;animation:starShift 140s linear infinite;pointer-events:none;}
+    @keyframes starShift{from{transform:translateY(0);}to{transform:translateY(-50%);}}
+    .teamPopup{background:rgba(0,0,0,.78);backdrop-filter:blur(4px);border-radius:10px;padding:1rem;min-width:200px;}
+    .game-container{display:flex;justify-content:center;gap:2rem;align-items:flex-start;padding-top:2rem;}
+    .playerName{cursor:move;}
+    .removeBtn{cursor:pointer;color:var(--red-team);}
+    .behaviorSelect{width:7rem;}
+  </style>
+</head>
+<body>
+  <h1 class="text-center mt-3">Game 2 – Under Construction</h1>
+  <div class="d-flex flex-column align-items-center mt-4">
+    <canvas id="qrCode"></canvas>
+    <p class="mt-2">Scan to join: <%= joinURL %></p>
+  </div>
+  <div class="game-container">
+    <div id="blueTeamPopup" class="teamPopup">
+      <h4>Blue Team</h4>
+      <ul id="playersLeft" class="list-unstyled"></ul>
+      <button id="addBotLeft" class="btn btn-sm btn-light mt-2">Add Bot</button>
+    </div>
+    <div id="redTeamPopup" class="teamPopup">
+      <h4>Red Team</h4>
+      <ul id="playersRight" class="list-unstyled"></ul>
+      <button id="addBotRight" class="btn btn-sm btn-light mt-2">Add Bot</button>
+    </div>
+  </div>
+  <script src="/socket.io/socket.io.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
+  <script>
+    const socket = io();
+    const joinURL = "<%= joinURL %>";
+    const botBehaviorNames = [];
+    QRCode.toCanvas(document.getElementById('qrCode'), joinURL);
+    const leftList = document.getElementById('playersLeft');
+    const rightList = document.getElementById('playersRight');
+    [leftList, rightList].forEach(el => el.addEventListener('dragover', e => e.preventDefault()));
+    function handleDrop(team){
+      return e => { e.preventDefault(); const id = e.dataTransfer.getData('playerId'); if(id) socket.emit('setTeam', { playerId:id, team }); };
+    }
+    leftList.addEventListener('drop', handleDrop('left'));
+    rightList.addEventListener('drop', handleDrop('right'));
+    document.getElementById('addBotLeft').addEventListener('click', () => socket.emit('addBot', 'left'));
+    document.getElementById('addBotRight').addEventListener('click', () => socket.emit('addBot', 'right'));
+    function updateTeamLists(data){
+      leftList.innerHTML='';
+      rightList.innerHTML='';
+      let leftCount=0,rightCount=0;
+      Object.values(data.players).forEach(p=>{
+        const li=document.createElement('li');
+        li.dataset.playerId=p.id;
+        const name=document.createElement('span');
+        name.className='playerName';
+        name.textContent=p.name||'Unnamed';
+        name.draggable=true;
+        name.addEventListener('dragstart',e=>{e.dataTransfer.setData('playerId',p.id);});
+        li.appendChild(name);
+        if(p.isBot){
+          const sel=document.createElement('select');
+          sel.className='form-select form-select-sm behaviorSelect';
+          botBehaviorNames.forEach(b=>{const opt=document.createElement('option');opt.value=b;opt.textContent=b;if(p.behavior===b)opt.selected=true;sel.appendChild(opt);});
+          sel.addEventListener('change',()=>{socket.emit('setBotBehavior',{botId:p.id,behavior:sel.value});});
+          li.appendChild(sel);
+        }
+        const remove=document.createElement('span');
+        remove.textContent='❌';
+        remove.className='removeBtn';
+        remove.draggable=false;
+        remove.addEventListener('click',ev=>{ev.preventDefault();ev.stopPropagation();socket.emit('removePlayer',li.dataset.playerId);li.remove();});
+        li.appendChild(remove);
+        if(p.team==='left'){leftList.appendChild(li);leftCount++;}else{rightList.appendChild(li);rightCount++;}
+      });
+      document.querySelector('#blueTeamPopup h4').textContent=`Blue Team (${leftCount})`;
+      document.querySelector('#redTeamPopup h4').textContent=`Red Team (${rightCount})`;
+    }
+    socket.on('gameState', updateTeamLists);
+  </script>
+</body>
+</html>

--- a/views/game2/mobile.ejs
+++ b/views/game2/mobile.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game 2 Controller – Under Construction</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <style>
+    body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#000;color:#fff;font-family:'Orbitron',sans-serif;text-align:center;}
+  </style>
+</head>
+<body>
+  <h1>Mobile controller under construction</h1>
+</body>
+</html>

--- a/views/game2/pc.ejs
+++ b/views/game2/pc.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game 2 PC Controller – Under Construction</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <style>
+    body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#000;color:#fff;font-family:'Orbitron',sans-serif;text-align:center;}
+  </style>
+</head>
+<body>
+  <h1>PC controller under construction</h1>
+</body>
+</html>

--- a/views/game3/game.ejs
+++ b/views/game3/game.ejs
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game 3 – Under Construction</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <style>
+    :root {
+      --blue-team:#00b3ff;
+      --red-team:#ff273d;
+      --neutral:#ffffff;
+      --bg-dark:#0a0d13;
+      --bg-mid:#142134;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    html,body{height:100%;width:100%;overflow:hidden;font-family:'Orbitron',sans-serif;color:var(--neutral);}
+    body{background:radial-gradient(ellipse at bottom,var(--bg-mid) 0%,var(--bg-dark) 100%);}
+    body::before{content:"";position:fixed;inset:0;width:300%;height:300%;background:url("https://raw.githubusercontent.com/Kieran-Brown/assets/main/stars_2.png") repeat;animation:starShift 140s linear infinite;pointer-events:none;}
+    @keyframes starShift{from{transform:translateY(0);}to{transform:translateY(-50%);}}
+    .teamPopup{background:rgba(0,0,0,.78);backdrop-filter:blur(4px);border-radius:10px;padding:1rem;min-width:200px;}
+    .game-container{display:flex;justify-content:center;gap:2rem;align-items:flex-start;padding-top:2rem;}
+    .playerName{cursor:move;}
+    .removeBtn{cursor:pointer;color:var(--red-team);}
+    .behaviorSelect{width:7rem;}
+  </style>
+</head>
+<body>
+  <h1 class="text-center mt-3">Game 3 – Under Construction</h1>
+  <div class="d-flex flex-column align-items-center mt-4">
+    <canvas id="qrCode"></canvas>
+    <p class="mt-2">Scan to join: <%= joinURL %></p>
+  </div>
+  <div class="game-container">
+    <div id="blueTeamPopup" class="teamPopup">
+      <h4>Blue Team</h4>
+      <ul id="playersLeft" class="list-unstyled"></ul>
+      <button id="addBotLeft" class="btn btn-sm btn-light mt-2">Add Bot</button>
+    </div>
+    <div id="redTeamPopup" class="teamPopup">
+      <h4>Red Team</h4>
+      <ul id="playersRight" class="list-unstyled"></ul>
+      <button id="addBotRight" class="btn btn-sm btn-light mt-2">Add Bot</button>
+    </div>
+  </div>
+  <script src="/socket.io/socket.io.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
+  <script>
+    const socket = io();
+    const joinURL = "<%= joinURL %>";
+    const botBehaviorNames = [];
+    QRCode.toCanvas(document.getElementById('qrCode'), joinURL);
+    const leftList = document.getElementById('playersLeft');
+    const rightList = document.getElementById('playersRight');
+    [leftList, rightList].forEach(el => el.addEventListener('dragover', e => e.preventDefault()));
+    function handleDrop(team){
+      return e => { e.preventDefault(); const id = e.dataTransfer.getData('playerId'); if(id) socket.emit('setTeam', { playerId:id, team }); };
+    }
+    leftList.addEventListener('drop', handleDrop('left'));
+    rightList.addEventListener('drop', handleDrop('right'));
+    document.getElementById('addBotLeft').addEventListener('click', () => socket.emit('addBot', 'left'));
+    document.getElementById('addBotRight').addEventListener('click', () => socket.emit('addBot', 'right'));
+    function updateTeamLists(data){
+      leftList.innerHTML='';
+      rightList.innerHTML='';
+      let leftCount=0,rightCount=0;
+      Object.values(data.players).forEach(p=>{
+        const li=document.createElement('li');
+        li.dataset.playerId=p.id;
+        const name=document.createElement('span');
+        name.className='playerName';
+        name.textContent=p.name||'Unnamed';
+        name.draggable=true;
+        name.addEventListener('dragstart',e=>{e.dataTransfer.setData('playerId',p.id);});
+        li.appendChild(name);
+        if(p.isBot){
+          const sel=document.createElement('select');
+          sel.className='form-select form-select-sm behaviorSelect';
+          botBehaviorNames.forEach(b=>{const opt=document.createElement('option');opt.value=b;opt.textContent=b;if(p.behavior===b)opt.selected=true;sel.appendChild(opt);});
+          sel.addEventListener('change',()=>{socket.emit('setBotBehavior',{botId:p.id,behavior:sel.value});});
+          li.appendChild(sel);
+        }
+        const remove=document.createElement('span');
+        remove.textContent='❌';
+        remove.className='removeBtn';
+        remove.draggable=false;
+        remove.addEventListener('click',ev=>{ev.preventDefault();ev.stopPropagation();socket.emit('removePlayer',li.dataset.playerId);li.remove();});
+        li.appendChild(remove);
+        if(p.team==='left'){leftList.appendChild(li);leftCount++;}else{rightList.appendChild(li);rightCount++;}
+      });
+      document.querySelector('#blueTeamPopup h4').textContent=`Blue Team (${leftCount})`;
+      document.querySelector('#redTeamPopup h4').textContent=`Red Team (${rightCount})`;
+    }
+    socket.on('gameState', updateTeamLists);
+  </script>
+</body>
+</html>

--- a/views/game3/mobile.ejs
+++ b/views/game3/mobile.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game 3 Controller – Under Construction</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <style>
+    body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#000;color:#fff;font-family:'Orbitron',sans-serif;text-align:center;}
+  </style>
+</head>
+<body>
+  <h1>Mobile controller under construction</h1>
+</body>
+</html>

--- a/views/game3/pc.ejs
+++ b/views/game3/pc.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game 3 PC Controller – Under Construction</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <style>
+    body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#000;color:#fff;font-family:'Orbitron',sans-serif;text-align:center;}
+  </style>
+</head>
+<body>
+  <h1>PC controller under construction</h1>
+</body>
+</html>

--- a/views/game4/game.ejs
+++ b/views/game4/game.ejs
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game 4 – Under Construction</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <style>
+    :root {
+      --blue-team:#00b3ff;
+      --red-team:#ff273d;
+      --neutral:#ffffff;
+      --bg-dark:#0a0d13;
+      --bg-mid:#142134;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    html,body{height:100%;width:100%;overflow:hidden;font-family:'Orbitron',sans-serif;color:var(--neutral);}
+    body{background:radial-gradient(ellipse at bottom,var(--bg-mid) 0%,var(--bg-dark) 100%);}
+    body::before{content:"";position:fixed;inset:0;width:300%;height:300%;background:url("https://raw.githubusercontent.com/Kieran-Brown/assets/main/stars_2.png") repeat;animation:starShift 140s linear infinite;pointer-events:none;}
+    @keyframes starShift{from{transform:translateY(0);}to{transform:translateY(-50%);}}
+    .teamPopup{background:rgba(0,0,0,.78);backdrop-filter:blur(4px);border-radius:10px;padding:1rem;min-width:200px;}
+    .game-container{display:flex;justify-content:center;gap:2rem;align-items:flex-start;padding-top:2rem;}
+    .playerName{cursor:move;}
+    .removeBtn{cursor:pointer;color:var(--red-team);}
+    .behaviorSelect{width:7rem;}
+  </style>
+</head>
+<body>
+  <h1 class="text-center mt-3">Game 4 – Under Construction</h1>
+  <div class="d-flex flex-column align-items-center mt-4">
+    <canvas id="qrCode"></canvas>
+    <p class="mt-2">Scan to join: <%= joinURL %></p>
+  </div>
+  <div class="game-container">
+    <div id="blueTeamPopup" class="teamPopup">
+      <h4>Blue Team</h4>
+      <ul id="playersLeft" class="list-unstyled"></ul>
+      <button id="addBotLeft" class="btn btn-sm btn-light mt-2">Add Bot</button>
+    </div>
+    <div id="redTeamPopup" class="teamPopup">
+      <h4>Red Team</h4>
+      <ul id="playersRight" class="list-unstyled"></ul>
+      <button id="addBotRight" class="btn btn-sm btn-light mt-2">Add Bot</button>
+    </div>
+  </div>
+  <script src="/socket.io/socket.io.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
+  <script>
+    const socket = io();
+    const joinURL = "<%= joinURL %>";
+    const botBehaviorNames = [];
+    QRCode.toCanvas(document.getElementById('qrCode'), joinURL);
+    const leftList = document.getElementById('playersLeft');
+    const rightList = document.getElementById('playersRight');
+    [leftList, rightList].forEach(el => el.addEventListener('dragover', e => e.preventDefault()));
+    function handleDrop(team){
+      return e => { e.preventDefault(); const id = e.dataTransfer.getData('playerId'); if(id) socket.emit('setTeam', { playerId:id, team }); };
+    }
+    leftList.addEventListener('drop', handleDrop('left'));
+    rightList.addEventListener('drop', handleDrop('right'));
+    document.getElementById('addBotLeft').addEventListener('click', () => socket.emit('addBot', 'left'));
+    document.getElementById('addBotRight').addEventListener('click', () => socket.emit('addBot', 'right'));
+    function updateTeamLists(data){
+      leftList.innerHTML='';
+      rightList.innerHTML='';
+      let leftCount=0,rightCount=0;
+      Object.values(data.players).forEach(p=>{
+        const li=document.createElement('li');
+        li.dataset.playerId=p.id;
+        const name=document.createElement('span');
+        name.className='playerName';
+        name.textContent=p.name||'Unnamed';
+        name.draggable=true;
+        name.addEventListener('dragstart',e=>{e.dataTransfer.setData('playerId',p.id);});
+        li.appendChild(name);
+        if(p.isBot){
+          const sel=document.createElement('select');
+          sel.className='form-select form-select-sm behaviorSelect';
+          botBehaviorNames.forEach(b=>{const opt=document.createElement('option');opt.value=b;opt.textContent=b;if(p.behavior===b)opt.selected=true;sel.appendChild(opt);});
+          sel.addEventListener('change',()=>{socket.emit('setBotBehavior',{botId:p.id,behavior:sel.value});});
+          li.appendChild(sel);
+        }
+        const remove=document.createElement('span');
+        remove.textContent='❌';
+        remove.className='removeBtn';
+        remove.draggable=false;
+        remove.addEventListener('click',ev=>{ev.preventDefault();ev.stopPropagation();socket.emit('removePlayer',li.dataset.playerId);li.remove();});
+        li.appendChild(remove);
+        if(p.team==='left'){leftList.appendChild(li);leftCount++;}else{rightList.appendChild(li);rightCount++;}
+      });
+      document.querySelector('#blueTeamPopup h4').textContent=`Blue Team (${leftCount})`;
+      document.querySelector('#redTeamPopup h4').textContent=`Red Team (${rightCount})`;
+    }
+    socket.on('gameState', updateTeamLists);
+  </script>
+</body>
+</html>

--- a/views/game4/mobile.ejs
+++ b/views/game4/mobile.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game 4 Controller – Under Construction</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <style>
+    body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#000;color:#fff;font-family:'Orbitron',sans-serif;text-align:center;}
+  </style>
+</head>
+<body>
+  <h1>Mobile controller under construction</h1>
+</body>
+</html>

--- a/views/game4/pc.ejs
+++ b/views/game4/pc.ejs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Game 4 PC Controller – Under Construction</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <style>
+    body{display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#000;color:#fff;font-family:'Orbitron',sans-serif;text-align:center;}
+  </style>
+</head>
+<body>
+  <h1>PC controller under construction</h1>
+</body>
+</html>

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>2D Multiplayer Games</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <style>
+    :root {
+      --blue-team:#00b3ff;
+      --red-team:#ff273d;
+      --neutral:#ffffff;
+      --bg-dark:#0a0d13;
+      --bg-mid:#142134;
+    }
+    *{margin:0;padding:0;box-sizing:border-box;}
+    html,body{height:100%;width:100%;overflow:hidden;font-family:'Orbitron',sans-serif;color:var(--neutral);}
+    body{background:radial-gradient(ellipse at bottom,var(--bg-mid) 0%,var(--bg-dark) 100%);}
+    body::before{content:"";position:fixed;inset:0;width:300%;height:300%;background:url("https://raw.githubusercontent.com/Kieran-Brown/assets/main/stars_2.png") repeat;animation:starShift 140s linear infinite;pointer-events:none;}
+    @keyframes starShift{from{transform:translateY(0);}to{transform:translateY(-50%);} }
+    .home-container{height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem;text-align:center;}
+    .games-grid{display:flex;flex-wrap:wrap;justify-content:center;}
+    .game-box{width:250px;height:150px;border-radius:10px;background:rgba(0,0,0,0.45);backdrop-filter:blur(5px);display:flex;justify-content:center;align-items:center;color:white;margin:1rem;cursor:pointer;text-decoration:none;transition:box-shadow .3s;}
+    .game-box:hover{box-shadow:0 0 10px rgba(255,255,255,0.8);}
+  </style>
+</head>
+<body>
+  <div class="home-container">
+    <h1 class="mb-4">2D Multiplayer Games</h1>
+    <div class="games-grid">
+      <a href="/space-battle" class="game-box">Space Battle</a>
+      <a href="/game2" class="game-box">Game 2</a>
+      <a href="/game3" class="game-box">Game 3</a>
+      <a href="/game4" class="game-box">Game 4</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a new `home.ejs` page styled like the game screen
- show four game boxes linking to `/space-battle`, `/game2`, `/game3`, and `/game4`
- serve the home page on `/`
- move existing game routes under `/space-battle`
- add placeholder views and routes for additional games
- update joinURL generation for each game route
- shrink placeholder game pages to an under‑construction view with QR code and team management

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687613730f308328875d38c8645e0f55