### PR TITLE
Add random unique names for bots

### DIFF
--- a/src/data/botNames.json
+++ b/src/data/botNames.json
@@ -1,0 +1,8 @@
+[
+  "Alex", "Jamie", "Taylor", "Jordan", "Morgan", "Casey", "Riley",
+  "Robin", "Dana", "Avery", "Charlie", "Dakota", "Emerson",
+  "Finley", "Harper", "Kendall", "Logan", "Parker", "Quinn",
+  "Reese", "Skyler", "Terry", "Vivian", "Cameron", "Jessie",
+  "Bailey", "Sydney", "Tracy", "Hayden", "Payton"
+]
+

--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -2,6 +2,7 @@
 const gameState = require('../models/gameState');
 const { upgradeMax } = require('../models/upgradeConfig');
 const botBehaviors = require('../botBehaviors');
+const { getRandomName, releaseName } = require('../utils/botNameManager');
 let gameLoopInterval;
 let ioInstance;
 let botCounter = 1;
@@ -557,9 +558,10 @@ function applyRandomUpgrade(bot) {
 function createBot(team) {
   const id = `bot_${botCounter}`;
   const behavior = botBehaviors.randomBehavior();
+  const randomName = getRandomName();
   const bot = {
     id,
-    name: `Bot${botCounter}`,
+    name: randomName || `Bot${botCounter}`,
     team,
     isBot: true,
     level: 1,
@@ -601,7 +603,11 @@ function createBotsPerTeam(count) {
 
 function removeBots() {
   Object.keys(gameState.players).forEach(id => {
-    if (gameState.players[id].isBot) delete gameState.players[id];
+    const p = gameState.players[id];
+    if (p.isBot) {
+      releaseName(p.name);
+      delete gameState.players[id];
+    }
   });
 }
 

--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -2,6 +2,7 @@
 const gameState = require('../models/gameState');
 const { spawnPlayer, createBotsPerTeam, removeBots, startTdmRound, createBot } = require('./gameLogic');
 const botBehaviors = require('../botBehaviors');
+const { releaseName } = require('../utils/botNameManager');
 const { TOTAL_UPGRADE_LEVELS, MAX_LEVEL_CAP, upgradeMax } = require('../models/upgradeConfig');
 
 function computeLevelCap(minutes) {
@@ -282,6 +283,9 @@ function initSocket(io) {
       if (gameState.players[playerId]) {
         if (!gameState.players[playerId].isBot) {
           io.to(playerId).emit('kicked');
+        }
+        if (gameState.players[playerId].isBot) {
+          releaseName(gameState.players[playerId].name);
         }
         delete gameState.players[playerId];
         const now = Date.now();

--- a/src/utils/botNameManager.js
+++ b/src/utils/botNameManager.js
@@ -1,0 +1,17 @@
+const names = require('../data/botNames.json');
+const used = new Set();
+
+function getRandomName() {
+  const available = names.filter(n => !used.has(n));
+  if (available.length === 0) return null;
+  const name = available[Math.floor(Math.random() * available.length)];
+  used.add(name);
+  return name;
+}
+
+function releaseName(name) {
+  used.delete(name);
+}
+
+module.exports = { getRandomName, releaseName };
+


### PR DESCRIPTION
## Summary
- add a list of common names for bots
- provide a bot name manager for random unique name selection
- use the name manager when creating bots
- release names when bots are removed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687630762fd48328b47effaed513fbc1