### PR TITLE
Fix pause screen sticking after restart/end

### DIFF
--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -194,6 +194,7 @@ function initSocket(io) {
         gameState.pointAreas.right = [];
         gameState.forceGameOver = false;
         gameState.currentRound = 0;
+        gameState.pauseTime = null;
         if (gameState.mode === 'tdm') {
           startTdmRound();
         } else {
@@ -228,6 +229,7 @@ function initSocket(io) {
         gameState.gameStarted = false;
         gameState.gameActive = false;
         gameState.gamePaused = false;
+        gameState.pauseTime = null;
         gameState.forceGameOver = true;
       }
     });
@@ -242,6 +244,7 @@ function initSocket(io) {
       gameState.gamePaused = false;
       gameState.gameActive = false;
       gameState.gameStartTime = null;
+      gameState.pauseTime = null;
       gameState.forceGameOver = false;
       gameState.currentRound = 0;
       Object.values(gameState.players).forEach(p => {


### PR DESCRIPTION
## Summary
- reset `pauseTime` when starting, ending or restarting a game so the pause popup doesn't get reopened

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aaf4321a4832892b73aa5645e1fdf