### PR TITLE
Fix upgrade access on mobile

### DIFF
--- a/views/game1 - Battle/mobile.ejs
+++ b/views/game1 - Battle/mobile.ejs
@@ -79,12 +79,13 @@
       flex-direction: column;
       padding: 1rem;
       border-left: 1px solid rgba(255,255,255,0.15);
+      overflow-y: auto;
     }
 
     /* --------‑‑‑ Responsive Portrait Adjustments ‑‑‑-------- */
     @media (orientation: portrait) {
       .controller-container { flex-direction: column; }
-      .right-panel { width: 100%; height: 42vh; border-left: none; border-top: 1px solid rgba(255,255,255,0.15);}  
+      .right-panel { width: 100%; height: 42vh; border-left: none; border-top: 1px solid rgba(255,255,255,0.15); overflow-y:auto; }
     }
 
     /* --------‑‑‑ Joystick ‑‑‑-------- */
@@ -312,7 +313,9 @@
     }
 
     document.querySelectorAll('.stat-upgrade').forEach(btn=>{
-      btn.addEventListener('click', ()=> socket.emit('upgrade', btn.dataset.upgrade));
+      const handler = () => socket.emit('upgrade', btn.dataset.upgrade);
+      btn.addEventListener('click', handler);
+      btn.addEventListener('touchstart', (e) => { e.preventDefault(); handler(); });
     });
 
     /* ---------- Leaderboard ---------- */


### PR DESCRIPTION
## Summary
- make mobile level-up buttons respond to touch while joystick is held
- allow upgrade table to scroll when screen space is limited

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab582f3c4832891a63d3e4f9718c2