### PR TITLE
Remove bullet glow in low animation mode

### DIFF
--- a/views/game1 - Battle/game.ejs
+++ b/views/game1 - Battle/game.ejs
@@ -364,6 +364,57 @@
     let showDamagePopups = true;
     let showKillMsgs = true;
     let nameSize = 16;
+
+    /* ----------------------------------------------------------
+      Drawing helpers for reusability
+    ---------------------------------------------------------- */
+    function drawBullet(bullet, frame){
+      if(useSimpleBullets){
+        const color = bullet.team === 'left' ? '#00b3ff' : '#ff273d';
+        ctx.beginPath();
+        ctx.fillStyle = color;
+        ctx.arc(bullet.x, bullet.y, bullet.radius, 0, Math.PI * 2);
+        ctx.fill();
+      } else {
+        const img = bulletSprites[bullet.team][frame];
+        if (img) ctx.drawImage(img, bullet.x - bullet.radius, bullet.y - bullet.radius, bullet.radius * 2, bullet.radius * 2);
+      }
+    }
+
+    function drawPlayer(p, data){
+      const sprite = p.team === 'left' ? blueSprite : redSprite;
+      const faded = data.mode === 'tdm' && !p.isAlive;
+      if (faded) ctx.globalAlpha = 0.35;
+      ctx.drawImage(sprite, p.x - p.radius, p.y - p.radius, p.radius * 2, p.radius * 2);
+      if (faded) { ctx.globalAlpha = 1; return; }
+
+      const barWidth  = p.radius * 2;
+      const barHeight = 6;
+      const barX      = p.x - barWidth / 2;
+      const barY      = p.y - p.radius - 36;
+
+      ctx.fillStyle = 'rgba(0,0,0,0.6)';
+      ctx.fillRect(barX, barY, barWidth, barHeight);
+      ctx.fillRect(barX, barY + barHeight + 2, barWidth, barHeight);
+
+      const shieldPct = (p.shield || 0) / (p.shieldMax || 1);
+      ctx.fillStyle = 'rgba(0,179,255,0.85)';
+      ctx.fillRect(barX, barY, barWidth * shieldPct, barHeight);
+
+      const hpPct = (p.lives || 0) / (p.maxLives || 1);
+      ctx.fillStyle = 'rgba(255,39,61,0.85)';
+      ctx.fillRect(barX, barY + barHeight + 2, barWidth * hpPct, barHeight);
+
+      ctx.font = nameSize + 'px Orbitron, sans-serif';
+      ctx.fillStyle = '#ffffff';
+      ctx.textAlign = 'center';
+      ctx.fillText(p.name || 'Anon', p.x, barY - 8);
+
+      ctx.font = 'bold 16px Orbitron, sans-serif';
+      ctx.fillStyle = '#000';
+      ctx.fillText(p.level, p.x, p.y + 6);
+    }
+
     const lowAnimCheck = document.getElementById('settingsLowAnim');
     const damageCheck = document.getElementById('damagePopupCheck');
     const killMsgCheck = document.getElementById('killMessageCheck');
@@ -835,72 +886,10 @@
       
       const frame = Math.floor(bulletFrameTick / 5) % 8;
       bulletFrameTick++;
-      data.bullets.forEach(bullet => {
-        if(useSimpleBullets){
-          const color = bullet.team === 'left' ? '#00b3ff' : '#ff273d';
-          ctx.beginPath();
-          ctx.fillStyle = color;
-          ctx.shadowColor = color;
-          ctx.shadowBlur = bullet.radius * 2;
-          ctx.arc(bullet.x, bullet.y, bullet.radius, 0, Math.PI * 2);
-          ctx.fill();
-          ctx.shadowBlur = 0;
-        } else {
-          const img = bulletSprites[bullet.team][frame];
-          if (img) ctx.drawImage(img, bullet.x - bullet.radius, bullet.y - bullet.radius, bullet.radius * 2, bullet.radius * 2);
-        }
-      });
-      
+      data.bullets.forEach(bullet => drawBullet(bullet, frame));
+
       for (const id in data.players) {
-        const p = data.players[id];
-
-        /* ----------------------------------------------------------
-          3A.  Draw the ship sprite
-        ---------------------------------------------------------- */
-        const sprite = p.team === 'left' ? blueSprite : redSprite;
-        const faded = data.mode==='tdm' && !p.isAlive;
-        if (faded) ctx.globalAlpha = 0.35;
-        ctx.drawImage(sprite, p.x - p.radius, p.y - p.radius,
-                      p.radius * 2, p.radius * 2);
-        if (faded) { ctx.globalAlpha = 1; continue; }
-
-        /* ----------------------------------------------------------
-          3B.  Shield + health bars
-        ---------------------------------------------------------- */
-        const barWidth  = p.radius * 2;
-        const barHeight = 6;
-        const barX      = p.x - barWidth / 2;
-        const barY      = p.y - p.radius - 36;   // adjust vertical gap here
-
-        // background rails
-        ctx.fillStyle = 'rgba(0,0,0,0.6)';
-        ctx.fillRect(barX, barY, barWidth, barHeight);
-        ctx.fillRect(barX, barY + barHeight + 2, barWidth, barHeight);
-
-        // blue shield
-        const shieldPct = (p.shield || 0) / (p.shieldMax || 1);
-        ctx.fillStyle = 'rgba(0,179,255,0.85)';
-        ctx.fillRect(barX, barY, barWidth * shieldPct, barHeight);
-
-        // red health
-        const hpPct = (p.lives || 0) / (p.maxLives || 1);
-        ctx.fillStyle = 'rgba(255,39,61,0.85)';
-        ctx.fillRect(barX, barY + barHeight + 2, barWidth * hpPct, barHeight);
-
-        /* ----------------------------------------------------------
-          3C.  Player name & stats
-        ---------------------------------------------------------- */
-        ctx.font = nameSize + 'px Orbitron, sans-serif';
-        ctx.fillStyle = '#ffffff';
-        ctx.textAlign = 'center';
-        ctx.fillText(p.name || 'Anon', p.x, barY - 8);
-
-        /* ----------------------------------------------------------
-          3D.  Level badge (black number on hull)
-        ---------------------------------------------------------- */
-        ctx.font = 'bold 16px Orbitron, sans-serif';
-        ctx.fillStyle = '#000';
-        ctx.fillText(p.level, p.x, p.y + 6);
+        drawPlayer(data.players[id], data);
       }
       drawFloatingTexts();
     }


### PR DESCRIPTION
## Summary
- stop drawing glow on simple bullets
- add reusable `drawBullet` and `drawPlayer` helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab67191f88328b8f04598d79c4168