### PR TITLE
Adjust winner popup width and limit player names

### DIFF
--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -33,7 +33,8 @@ function initSocket(io) {
 
     // Handle joinWithName event from mobile controller (pre-game)
     socket.on('joinWithName', (info) => {
-      const name = typeof info === 'string' ? info : info.name;
+      let name = typeof info === 'string' ? info : info.name;
+      name = (name || '').substring(0, 20); // enforce max length
       const device = info?.device || 'unknown';
       console.log(`Player ${socket.id} joined with name: ${name}`);
       const team = assignTeam();

--- a/views/game1 - Battle/game.ejs
+++ b/views/game1 - Battle/game.ejs
@@ -166,6 +166,9 @@
     .popupBtn:hover{box-shadow:0 0 6px var(--neutral);}    
 
     #leaderboardPopup>div{display:flex;gap:2rem;flex-wrap:wrap;justify-content:center;max-width:90vw;}
+    .winner-content{width:fit-content;max-width:90vw;}
+    .winner-content table{width:auto;}
+    .winner-content th,.winner-content td{white-space:nowrap;}
 
     /* Winner grid */
     #winnerPopupInner{display:grid;grid-template-columns:1fr 1fr;gap:2rem;}
@@ -254,20 +257,22 @@
   <div id="pausePopup" class="popup"><button id="continueButton" class="popupBtn">Continue</button><button id="restartButton" class="popupBtn">Restart</button><button id="endButton" class="popupBtn">End Game</button><button id="openSettingsPause" class="popupBtn">Settings</button></div>
   <div id="leaderboardPopup" class="popup"><h2>Leaderboard</h2><div><div><h3 style="color:var(--blue-team)">Blue Fleet</h3><table id="lbBlue" class="table table-dark table-sm"></table></div><div><h3 style="color:var(--red-team)">Red Fleet</h3><table id="lbRed" class="table table-dark table-sm"></table></div></div></div>
 
-  <div id="winnerPopup" class="popup" style="max-width:950px;margin:auto;">
-    <h2 id="winnerTitle"></h2>
-    <div id="winnerPopupInner" class="mt-2">
-      <div>
-        <h3 style="color:var(--blue-team)">Blue Team</h3>
-        <table id="winnerBlue" class="table table-dark table-sm"></table>
+  <div id="winnerPopup" class="popup">
+    <div id="winnerPopupContent" class="winner-content">
+      <h2 id="winnerTitle"></h2>
+      <div id="winnerPopupInner" class="mt-2">
+        <div>
+          <h3 style="color:var(--blue-team)">Blue Team</h3>
+          <table id="winnerBlue" class="table table-dark table-sm"></table>
+        </div>
+        <div>
+          <h3 style="color:var(--red-team)">Red Team</h3>
+          <table id="winnerRed" class="table table-dark table-sm"></table>
+        </div>
       </div>
-      <div>
-        <h3 style="color:var(--red-team)">Red Team</h3>
-        <table id="winnerRed" class="table table-dark table-sm"></table>
-      </div>
+      <div class="mt-2"><span id="timer">Time: 0s</span> | <span id="scoreboard">Blue: 0 - Red: 0</span></div>
+      <div class="mt-3"><button id="exitButton" class="popupBtn">Exit</button><button id="restartFinal" class="popupBtn">Restart</button></div>
     </div>
-    <div class="mt-2"><span id="timer">Time: 0s</span> | <span id="scoreboard">Blue: 0 - Red: 0</span></div>
-    <div class="mt-3"><button id="exitButton" class="popupBtn">Exit</button><button id="restartFinal" class="popupBtn">Restart</button></div>
   </div>
 
   <div id="settingsPopup" class="popup">

--- a/views/game1 - Battle/mobile.ejs
+++ b/views/game1 - Battle/mobile.ejs
@@ -174,7 +174,7 @@
 
   <!-- Name Entry Screen -->
   <div id="nameEntry">
-    <input type="text" id="playerName" class="form-control text-center" placeholder="Commander name">
+    <input type="text" id="playerName" class="form-control text-center" placeholder="Commander name" maxlength="20">
     <button id="submitName" class="btn btn-primary"><i class="bi bi-rocket-takeoff"></i> Join Game</button>
   </div>
 

--- a/views/game1 - Battle/pc.ejs
+++ b/views/game1 - Battle/pc.ejs
@@ -138,7 +138,7 @@
     <button id="startJoin" class="btn btn-primary">Join Game</button>
   </div>
   <div id="nameEntry">
-    <input id="playerName" class="form-control" placeholder="Commander name">
+    <input id="playerName" class="form-control" placeholder="Commander name" maxlength="20">
     <button id="joinBtn" class="btn btn-primary"><i class="bi bi-rocket-takeoff"></i> Join</button>
   </div>
 


### PR DESCRIPTION
## Summary
- limit player name length to 20 chars
- add maxlength attribute to the player name inputs
- wrap winner popup content in a new container
- make winner popup width flexible so long names fit without clipping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687abd64a0e083288fe5ab24dfb3849e