### PR TITLE
Implement balance tweaks and upgrade adjustments

### DIFF
--- a/public/modals.js
+++ b/public/modals.js
@@ -1,0 +1,56 @@
+(function(){
+  class Modal {
+    constructor(opts){
+      this.el = document.createElement('div');
+      this.el.className = 'modal-bg';
+      this.box = document.createElement('div');
+      this.box.className = 'modal-box';
+      if(opts.title){
+        const h = document.createElement('h3');
+        h.textContent = opts.title;
+        this.box.appendChild(h);
+      }
+      this.form = document.createElement('div');
+      this.box.appendChild(this.form);
+      const btnRow = document.createElement('div');
+      btnRow.style.marginTop = '1rem';
+      const save = document.createElement('button');
+      save.textContent = 'Apply';
+      btnRow.appendChild(save);
+      this.box.appendChild(btnRow);
+      this.el.appendChild(this.box);
+      document.body.appendChild(this.el);
+      save.addEventListener('click', ()=>{ if(this.onSave) this.onSave(); this.close(); });
+    }
+    addNumberField(label, key){
+      const wrap = document.createElement('label');
+      wrap.textContent = label;
+      const inp = document.createElement('input');
+      inp.type = 'number';
+      inp.value = settings[key];
+      inp.oninput = ()=> settings[key] = parseFloat(inp.value);
+      wrap.appendChild(inp);
+      wrap.style.display = 'block';
+      wrap.style.margin = '4px 0';
+      this.form.appendChild(wrap);
+    }
+    open(){ this.el.style.display = 'flex'; }
+    close(){ this.el.remove(); }
+  }
+  function showBalanceModal(){
+    const modal = new Modal({ title:'Balance Tweaker' });
+    modal.addNumberField('Passive XP /s','XP_PASSIVE');
+    modal.addNumberField('XP per Hit','XP_PER_HIT');
+    modal.addNumberField('XP per Kill','XP_PER_KILL');
+    modal.addNumberField('XP Base','xpBase');
+    modal.addNumberField('XP Growth Exp','xpGrowthExp');
+    modal.addNumberField('Damage +0-4','dmgStepLow');
+    modal.addNumberField('Damage @5','dmgStepCap');
+    modal.addNumberField('Damage post-5','dmgStepHi');
+    modal.onSave = ()=>{
+      if(window.socket) socket.emit('reloadSettings', settings);
+    };
+    modal.open();
+  }
+  window.showBalanceModal = showBalanceModal;
+})();

--- a/src/controllers/gameController.js
+++ b/src/controllers/gameController.js
@@ -20,7 +20,8 @@ module.exports = (app) => {
       defaultCap: gameState.levelCap,
       upgradeBreakdown,
       botBehaviors: Object.keys(behaviors),
-      musicTracks
+      musicTracks,
+      settings: require('../models/settings').settings
     });
   }
 

--- a/src/models/constants.js
+++ b/src/models/constants.js
@@ -1,0 +1,9 @@
+const XP_PASSIVE = 1; // per second
+const XP_PER_HIT = 2;
+const XP_PER_KILL = 5;
+
+module.exports = {
+  XP_PASSIVE,
+  XP_PER_HIT,
+  XP_PER_KILL
+};

--- a/src/models/settings.js
+++ b/src/models/settings.js
@@ -1,0 +1,20 @@
+const { XP_PASSIVE, XP_PER_HIT, XP_PER_KILL } = require('./constants');
+
+const settings = {
+  XP_PASSIVE,
+  XP_PER_HIT,
+  XP_PER_KILL,
+  xpBase: 10,
+  xpGrowthExp: 0,
+  dmgStepLow: 0.75,
+  dmgStepCap: 2,
+  dmgStepHi: 1
+};
+
+function xpRequired(level) {
+  const base = settings.xpBase ?? 10;
+  const growth = settings.xpGrowthExp ?? 0;
+  return Math.ceil(base * Math.pow(level, growth));
+}
+
+module.exports = { settings, xpRequired };

--- a/src/models/upgradeConfig.js
+++ b/src/models/upgradeConfig.js
@@ -1,5 +1,5 @@
 const upgradeMax = {
-  moreDamage: 5,
+  moreDamage: Infinity,
   diagonalBullets: 3,
   shield: 5,
   moreBullets: 5,

--- a/views/game1 - Battle/game.ejs
+++ b/views/game1 - Battle/game.ejs
@@ -137,8 +137,9 @@
     /* Row with scores + timer */
     #scoreContainer{width:100%;display:flex;align-items:center;gap:.6rem;padding:6px 12px;}
     .scoreBox{flex:0 0 auto;font-size:2rem;padding:.1rem 1rem;border-radius:6px;background:var(--neutral);color:#000;border:3px solid var(--neutral);} /* default white outline, overridden below */
-    .scoreBlue{border-color:var(--blue-team);}    
-    .scoreRed {border-color:var(--red-team);}    
+    .scoreBlue{border-color:var(--blue-team);}
+    .scoreRed {border-color:var(--red-team);}
+    .balance-btn{position:absolute;top:8px;right:8px;font-size:1rem;padding:4px 8px;pointer-events:auto;}
 
     #timeBarContainer{flex:1;position:relative;height:22px;}
     #timeSegments{display:flex;height:100%;margin:0;padding:0;list-style:none;}
@@ -251,6 +252,7 @@
       <div id="redScore" class="scoreBox scoreRed">0</div>
     </div>
     <button id="pauseButton">II</button>
+    <button class="balance-btn" onclick="showBalanceModal()">⚙️ Balance</button>
   </div>
 
   <!-- GENERIC POPUPS -->
@@ -332,8 +334,10 @@
   <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
   <script src="/trackChooser.js"></script>
   <script src="/settingsPopup.js"></script>
+  <script src="/modals.js"></script>
   <script>
     const socket = io();
+    window.socket = socket;
     const canvas = document.getElementById('gameCanvas');
     const ctx = canvas.getContext('2d');
 
@@ -502,6 +506,7 @@
     const joinURL = "<%= joinURL %>";
     const botBehaviorNames = <%- JSON.stringify(botBehaviors) %>;
     const musicTracks = <%- JSON.stringify(musicTracks) %>;
+    const settings = <%- JSON.stringify(settings) %>;
     const music = document.getElementById('bgMusic');
     const volSlider = document.getElementById('musicVolume');
     const muteBtn = document.getElementById('muteButton');

--- a/views/game1 - Battle/mobile.ejs
+++ b/views/game1 - Battle/mobile.ejs
@@ -256,7 +256,7 @@
 
     /* ---------- Player / Game Updates ---------- */
     const upgradeOptions = {
-      moreDamage: { max:5 },
+      moreDamage: { max:Infinity },
       diagonalBullets: { max:3 },
       shield: { max:5 },
       moreBullets: { max:5 },


### PR DESCRIPTION
## Summary
- add global settings and XP constants
- update upgrade rules and leveling logic
- expose new balance modal for runtime tuning
- allow infinite damage upgrades
- tweak UI for balance controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ac4c3a26c8328966445cf09c2bd6c