### PR TITLE
Add balance controls and simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ Below are example screenshots located in the `public/images` folder:
 ![Game 4](public/images/game4/screenshot1.png)
 
 Feel free to explore and modify the code. Feedback is welcome!
+
+## Testing Balancing
+
+Run a quick simulation of a 120 second bot-only battle to evaluate balance tweaks:
+
+```bash
+npm run sim-battle
+```
+
+The script prints the levels reached by the bots, total experience earned, a histogram of DPS values and the peak bullet count observed during the run.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "scripts": {
     "test": "node --test",
-    "start": "node server.js"
+    "start": "node server.js",
+    "sim-battle": "node scripts/simBattle.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/simBattle.js
+++ b/scripts/simBattle.js
@@ -1,0 +1,66 @@
+const gameState = require('../src/models/gameState');
+const { startGameLoop, createBotsPerTeam } = require('../src/services/gameLogic');
+const { TOTAL_UPGRADE_LEVELS, MAX_LEVEL_CAP } = require('../src/models/upgradeConfig');
+const { settings } = require('../src/models/settings');
+
+const DURATION = 120000;
+const STEP = 1000 / 60;
+
+function computeLevelCap(minutes) {
+  const ratio = Math.min(minutes, 10) / 10;
+  const cap = Math.floor(TOTAL_UPGRADE_LEVELS * 0.75 * Math.pow(ratio, 0.7)) + 1;
+  return Math.min(cap, MAX_LEVEL_CAP);
+}
+
+let bulletPeak = 0;
+let simTime = 0;
+const realStart = Date.now();
+const origSetInterval = global.setInterval;
+const origClearInterval = global.clearInterval;
+
+global.setInterval = (fn, interval) => {
+  if (interval === STEP) {
+    while (simTime < DURATION) {
+      fn();
+      if (gameState.bullets.length > bulletPeak) bulletPeak = gameState.bullets.length;
+      simTime += interval;
+    }
+    return 0;
+  }
+  return origSetInterval(fn, interval);
+};
+
+global.clearInterval = () => {};
+Date.now = () => realStart + simTime;
+
+// init state
+Object.assign(gameState, {
+  players: {},
+  bullets: [],
+  scoreBlue: 0,
+  scoreRed: 0,
+  gameDuration: DURATION,
+  levelCap: computeLevelCap(DURATION / 60000),
+  gameStarted: true,
+  gameActive: true,
+  gameStartTime: Date.now(),
+});
+
+createBotsPerTeam(3);
+
+startGameLoop({ emit: () => {}, to: () => ({ emit: () => {} }) });
+
+const players = Object.values(gameState.players);
+const levels = players.map(p => p.level);
+const totalXp = players.reduce((a, p) => a + p.exp, 0);
+const dpsHist = {};
+players.forEach(p => {
+  const dps = p.damage / (DURATION / 1000);
+  const bucket = Math.round(dps);
+  dpsHist[bucket] = (dpsHist[bucket] || 0) + 1;
+});
+
+console.log('Levels reached:', levels);
+console.log('Total XP:', Math.round(totalXp));
+console.log('DPS histogram:', dpsHist);
+console.log('Bullet count peak:', bulletPeak);

--- a/views/game1 - Battle/game.ejs
+++ b/views/game1 - Battle/game.ejs
@@ -139,7 +139,7 @@
     .scoreBox{flex:0 0 auto;font-size:2rem;padding:.1rem 1rem;border-radius:6px;background:var(--neutral);color:#000;border:3px solid var(--neutral);} /* default white outline, overridden below */
     .scoreBlue{border-color:var(--blue-team);}
     .scoreRed {border-color:var(--red-team);}
-    .balance-btn{position:absolute;top:8px;right:8px;font-size:1rem;padding:4px 8px;pointer-events:auto;}
+    .balance-btn{position:absolute;bottom:8px;left:8px;font-size:1rem;padding:4px 8px;pointer-events:auto;}
 
     #timeBarContainer{flex:1;position:relative;height:22px;}
     #timeSegments{display:flex;height:100%;margin:0;padding:0;list-style:none;}
@@ -232,7 +232,6 @@
           </div>
         </td>
       </tr>
-      <tr id="levelRow"><td><label for="maxLevelInput">Max Levels</label></td><td><input type="number" id="maxLevelInput" value="<%= defaultCap %>" min="1" max="<%= maxAllowedCap %>" class="form-control form-control-sm"></td></tr>
       <tr><td><label for="gameModeSelect">Game Mode</label></td><td><select id="gameModeSelect" class="form-select form-select-sm"><option value="classic">Casual</option><option value="control">Point Control</option><option value="tdm">Team Deathmatch</option></select></td></tr>
       <tr id="spawnRow" style="display:none;"><td><label for="pointSpawnInput">Point Duration</label></td><td><div class="d-flex gap-1"><input type="number" id="pointSpawnInput" value="30" min="5" max="60" class="form-control form-control-sm" style="width:5rem;"><span class="align-self-center">sec</span></div></td></tr>
       <tr id="sizeRow" style="display:none;"><td><label for="pointSizeSelect">Area Size</label></td><td><select id="pointSizeSelect" class="form-select form-select-sm" style="width:6rem;"><option value="50">50%</option><option value="100" selected>100%</option><option value="150">150%</option><option value="200">200%</option></select></td></tr>
@@ -586,7 +585,6 @@
       const isTdm = modeSelect.value === 'tdm';
       const isControl = modeSelect.value === 'control';
       document.querySelector('#timeRow label').textContent = isTdm ? 'Round Time' : 'Game Time';
-      document.getElementById('levelRow').style.display = isTdm ? 'none' : '';
       document.getElementById('roundRow').style.display = isTdm ? '' : 'none';
       document.getElementById('spawnRow').style.display = isControl ? '' : 'none';
       document.getElementById('sizeRow').style.display = isControl ? '' : 'none';
@@ -598,11 +596,9 @@
       const mins = parseInt(document.getElementById('gameTimeMinutes').value) || 0;
       const secs = parseInt(document.getElementById('gameTimeSeconds').value) || 0;
       const minutes = mins + secs / 60;
-      const lvl = document.getElementById('maxLevelInput').value;
       const mode = modeSelect.value;
       if (mode !== 'tdm') {
         socket.emit('setGameTime', minutes);
-        socket.emit('setMaxLevels', lvl);
       } else {
         const rounds = document.getElementById('maxRoundsInput').value;
         socket.emit('setGameTime', minutes); // round duration


### PR DESCRIPTION
## Summary
- expose balance tweak modal button at bottom left
- remove manual max level option and rely on time-based calculation
- document new sim-battle script
- create headless battle simulation

## Testing
- `npm test`
- `npm run sim-battle`

------
https://chatgpt.com/codex/tasks/task_e_687b434000408328ae8a1a959c0d1af0