### PR TITLE
Implement time-based level cap

### DIFF
--- a/scripts/simBattle.js
+++ b/scripts/simBattle.js
@@ -1,15 +1,16 @@
 const gameState = require('../src/models/gameState');
 const { startGameLoop, createBotsPerTeam } = require('../src/services/gameLogic');
-const { TOTAL_UPGRADE_LEVELS, MAX_LEVEL_CAP } = require('../src/models/upgradeConfig');
+const { MAX_LEVEL_CAP } = require('../src/models/upgradeConfig');
 const { settings } = require('../src/models/settings');
+const { maxLevelAtTime } = require('../src/utils/levelUtils');
 
 const DURATION = 120000;
 const STEP = 1000 / 60;
 
 function computeLevelCap(minutes) {
-  const ratio = Math.min(minutes, 10) / 10;
-  const cap = Math.floor(TOTAL_UPGRADE_LEVELS * 0.75 * Math.pow(ratio, 0.7)) + 1;
-  return Math.min(cap, MAX_LEVEL_CAP);
+  const tSec = Math.min(minutes, 10) * 60;
+  const avg = settings.XP_PASSIVE;
+  return Math.min(maxLevelAtTime(tSec, avg), MAX_LEVEL_CAP);
 }
 
 let bulletPeak = 0;

--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -3,13 +3,14 @@ const gameState = require('../models/gameState');
 const { spawnPlayer, createBotsPerTeam, removeBots, startTdmRound, createBot } = require('./gameLogic');
 const botBehaviors = require('../botBehaviors');
 const { releaseName } = require('../utils/botNameManager');
-const { TOTAL_UPGRADE_LEVELS, MAX_LEVEL_CAP, upgradeMax } = require('../models/upgradeConfig');
+const { MAX_LEVEL_CAP, upgradeMax } = require('../models/upgradeConfig');
 const { settings } = require('../models/settings');
+const { maxLevelAtTime } = require('../utils/levelUtils');
 
 function computeLevelCap(minutes) {
-  const ratio = Math.min(minutes, 10) / 10;
-  const cap = Math.floor(TOTAL_UPGRADE_LEVELS * 0.75 * Math.pow(ratio, 0.7)) + 1;
-  return Math.min(cap, MAX_LEVEL_CAP);
+  const tSec = Math.min(minutes, 10) * 60;
+  const avg = settings.XP_PASSIVE;
+  return Math.min(maxLevelAtTime(tSec, avg), MAX_LEVEL_CAP);
 }
 
 // set initial level cap based on default duration

--- a/src/utils/levelUtils.js
+++ b/src/utils/levelUtils.js
@@ -1,0 +1,18 @@
+const { settings } = require('../models/settings');
+
+/**
+ * Returns the highest whole level reachable after tSec seconds,
+ * given an averageXPPerSec, xpBase, and xpGrowthExp.
+ */
+function maxLevelAtTime(tSec, averageXPPerSec,
+                        xpBase = settings.xpBase,
+                        alpha  = settings.xpGrowthExp) {
+  if (alpha === 0) {                      // flat cost
+    return Math.floor((averageXPPerSec * tSec) / xpBase);
+  }
+
+  const top = (alpha + 1) * averageXPPerSec * tSec / xpBase;
+  return Math.floor(Math.pow(top, 1 / (alpha + 1)));
+}
+
+module.exports = { maxLevelAtTime };

--- a/test/levelUtils.test.js
+++ b/test/levelUtils.test.js
@@ -1,0 +1,15 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const { maxLevelAtTime } = require('../src/utils/levelUtils');
+
+// Using flat cost (alpha = 0)
+test('maxLevelAtTime flat growth', () => {
+  const level = maxLevelAtTime(120, 1, 10, 0); // 120 sec at 1 xp/s, base 10
+  assert.strictEqual(level, 12);
+});
+
+test('maxLevelAtTime exponential growth', () => {
+  const level = maxLevelAtTime(120, 1, 10, 1); // alpha=1
+  assert.strictEqual(level, 4); // sqrt(24) -> 4.89 -> floor 4
+});


### PR DESCRIPTION
## Summary
- add a helper to compute the maximum level achievable after a period of time
- calculate level caps in socket handler and simBattle using the new formula
- test the new function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b4a1be1f08328a20fed4f4061ba8c