### PR TITLE
Fix red shield color and show balance button

### DIFF
--- a/views/game1 - Battle/game.ejs
+++ b/views/game1 - Battle/game.ejs
@@ -133,6 +133,7 @@
     #qrContainer .btn,
     .teamPopup .btn{min-width:7rem;}
     #startButtons .btn{flex:1;}
+    #balanceRow .btn{flex:1;}
 
     /* ===== HUD ===== */
     #overlay{position:absolute;top:0;left:0;width:100%;pointer-events:none;display:flex;flex-direction:column;align-items:center;}
@@ -448,7 +449,9 @@
         ctx.fillRect(barX, barY + barHeight + 2, barWidth, barHeight); // health rail
 
         const shieldPct = (p.shield || 0) / (p.shieldMax || 1);
-        const shieldColor = p.team === 'left' ? 'rgba(0,179,255,0.85)' : 'rgba(255,39,61,0.85)';
+        const shieldColor = p.team === 'left'
+          ? 'rgba(0,179,255,0.85)'
+          : 'rgba(214,45,32,0.85)';
         if(useSimpleBullets || p.shieldMax === 0){
           ctx.fillStyle = shieldColor;
           ctx.fillRect(barX, barY, barWidth * shieldPct, barHeight);

--- a/views/game1 - Battle/pc.ejs
+++ b/views/game1 - Battle/pc.ejs
@@ -302,7 +302,9 @@ let currentTeam = null;
       ctx.fillRect(x, y, bw, bh);            // rail shield
       ctx.fillRect(x, y + bh + 2, bw, bh);   // rail health
 
-      const shieldColor = p.team === 'left' ? 'rgba(0,179,255,.9)' : 'rgba(255,39,61,.9)';
+      const shieldColor = p.team === 'left'
+        ? 'rgba(0,179,255,.9)'
+        : 'rgba(214,45,32,.9)';
       ctx.fillStyle = shieldColor;  // shield color by team
       ctx.fillRect(x, y, bw * ((p.shield || 0) / (p.shieldMax || 1)), bh);
 


### PR DESCRIPTION
## Summary
- make red team's shield border actually red
- ensure balance button in start screen uses same layout as other controls

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687bf7ec184c8328945076b2deb5e698