### PR TITLE
Round up numeric displays

### DIFF
--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -219,7 +219,7 @@ function startGameLoop(io) {
             ioInstance.emit('regenPopup', {
               x: player.x,
               y: player.y - player.radius,
-              amount: gained,
+              amount: Math.ceil(gained),
               type: 'health'
             });
           }
@@ -293,7 +293,7 @@ function startGameLoop(io) {
               ioInstance.emit('damagePopup', {
                 x: player.x,
                 y: player.y - player.radius,
-                amount: dmgAmount
+                amount: Math.ceil(dmgAmount)
               });
             }
             const shooter = gameState.players[bullet.shooterId];

--- a/views/game1 - Battle/game.ejs
+++ b/views/game1 - Battle/game.ejs
@@ -853,13 +853,13 @@
 
     socket.on('damagePopup', ({ x, y, amount }) => {
       if(showDamagePopups){
-        spawnFloatingText({ x, y, text: `-${amount}`, color: '#ff273d' });
+        spawnFloatingText({ x, y, text: `-${Math.ceil(amount)}`, color: '#ff273d' });
       }
     });
 
     socket.on('regenPopup', ({ x, y, amount, type }) => {
       const color = type === 'shield' ? '#00b3ff' : '#00ff80';           // blue or green
-      spawnFloatingText({ x, y, text: `+${amount}`, color });
+      spawnFloatingText({ x, y, text: `+${Math.ceil(amount)}`, color });
     });
 
     socket.on('roundStart', ({ round }) => {
@@ -895,7 +895,8 @@
       } else {
         title.textContent = 'Winner Red Team';
       }
-      document.getElementById('scoreboard').textContent = `Blue: ${data.scoreBlue} - Red: ${data.scoreRed}`;
+      document.getElementById('scoreboard').textContent =
+        `Blue: ${Math.ceil(data.scoreBlue)} - Red: ${Math.ceil(data.scoreRed)}`;
       const header = '<thead><tr><th>Name</th><th>Kills</th><th>Deaths</th><th>Assists</th><th>Damage</th><th>Score</th></tr></thead><tbody></tbody>';
       blueTable.innerHTML = header;
       redTable.innerHTML = header;
@@ -905,7 +906,7 @@
       const all = Object.values(data.players)
         .concat(Object.values(data.disconnectedPlayers || {}));
       const calcScore = p =>
-        (p.kills || 0) * 50 + (p.assists || 0) * 10 + (p.damage || 0);
+        Math.ceil((p.kills || 0) * 50 + (p.assists || 0) * 10 + (p.damage || 0));
       const blue = all
         .filter(p => p.team === 'left')
         .sort((a, b) => calcScore(b) - calcScore(a));
@@ -920,7 +921,7 @@
           const device = p.device==='pc' ? '<i class="bi bi-pc-display"></i>' : '<i class="bi bi-phone"></i>';
           const disc = p.disconnected ? ' <i class="bi bi-wifi-off text-warning"></i>' : '';
           const name = truncateName(p.name || 'Unnamed');
-          row.innerHTML = `<td class="nameCell">${name} ${device}${disc}</td><td>${p.kills || 0}</td><td>${p.deaths || 0}</td><td>${p.assists || 0}</td><td>${p.damage || 0}</td><td>${score}</td>`;
+          row.innerHTML = `<td class="nameCell">${name} ${device}${disc}</td><td>${p.kills || 0}</td><td>${p.deaths || 0}</td><td>${p.assists || 0}</td><td>${Math.ceil(p.damage || 0)}</td><td>${score}</td>`;
           body.appendChild(row);
         });
       }

--- a/views/game1 - Battle/pc.ejs
+++ b/views/game1 - Battle/pc.ejs
@@ -214,10 +214,10 @@ let currentTeam = null;
     3.  SOCKET POP-UPS
   ======================================================== */
   socket.on('damagePopup', ({ x, y, amount }) =>
-    spawnFloat({ x, y, text: `-${amount}`, color: '#ff273d' })
+    spawnFloat({ x, y, text: `-${Math.ceil(amount)}`, color: '#ff273d' })
   );
   socket.on('regenPopup',  ({ x, y, amount, type }) =>
-    spawnFloat({ x, y, text: `+${amount}`, color: type === 'shield' ? '#00b3ff' : '#00ff80' })
+    spawnFloat({ x, y, text: `+${Math.ceil(amount)}`, color: type === 'shield' ? '#00b3ff' : '#00ff80' })
   );
   socket.on('roundStart', ({ round }) => showRoundTitle('Round ' + round));
   socket.on('roundEnd', ({ winner }) => {


### PR DESCRIPTION
## Summary
- ceiling regen/damage popup amounts on the server
- round up damage/healing amounts on the client
- round up team scores and scoreboard calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0cd3163c8328af59f99882a08769