### PR TITLE
Add persistent balance settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ npm run sim-battle
 ```
 
 The script prints the levels reached by the bots, total experience earned, a histogram of DPS values and the peak bullet count observed during the run.
+
+Balance values are stored in `src/data/balanceSettings.json`. The server and
+the simulation will create this file with default values if it does not exist
+and then load the settings from it on every run.

--- a/scripts/simBattle.js
+++ b/scripts/simBattle.js
@@ -1,3 +1,6 @@
+const { loadSettings } = require('../src/services/settingsService');
+loadSettings();
+
 const gameState = require('../src/models/gameState');
 const { startGameLoop, createBotsPerTeam } = require('../src/services/gameLogic');
 const { MAX_LEVEL_CAP } = require('../src/models/upgradeConfig');

--- a/server.js
+++ b/server.js
@@ -5,6 +5,9 @@ const socketIO = require('socket.io');
 const path = require('path');
 const fs = require('fs');
 
+const { loadSettings } = require('./src/services/settingsService');
+loadSettings();
+
 const { getLocalIp, publishService, stopService } = require('./src/services/networkService');
 const { initSocket } = require('./src/services/socketHandler');
 const { startGameLoop, stopGameLoop } = require('./src/services/gameLogic');

--- a/src/services/settingsService.js
+++ b/src/services/settingsService.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const { settings } = require('../models/settings');
+
+const settingsPath = path.join(__dirname, '../data/balanceSettings.json');
+
+function loadSettings() {
+  if (!fs.existsSync(settingsPath)) {
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  } else {
+    try {
+      const data = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      Object.assign(settings, data);
+    } catch (err) {
+      console.error('Failed to read balance settings:', err);
+    }
+  }
+  return settings;
+}
+
+module.exports = { loadSettings, settingsPath };
+


### PR DESCRIPTION
## Summary
- create a `settingsService` to read or create `balanceSettings.json`
- load the settings on server startup
- load the settings before running the simulation
- document the new json file location

## Testing
- `npm test`
- `npm run sim-battle`

------
https://chatgpt.com/codex/tasks/task_e_687c79805644832895c50d44d327a2b7