### PR TITLE
Fix final round scoreboard

### DIFF
--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -478,12 +478,13 @@ function endTdmRound(winner) {
   else if (winner === 'right') gameState.scoreRed++;
   gameState.currentRound++;
   gameState.gameStarted = false;
-  gameState.gameStartTime = null;
   if (ioInstance) ioInstance.emit('roundEnd', { winner });
   if (gameState.currentRound >= gameState.maxRounds) {
+    // keep gameStartTime so clients can detect game over
     gameState.forceGameOver = true;
     gameState.gameActive = false;
   } else {
+    gameState.gameStartTime = null;
     if (ioInstance) {
       let count = 3;
       const interval = setInterval(() => {
@@ -664,6 +665,7 @@ module.exports = {
   createBotsPerTeam,
   removeBots,
   startTdmRound,
+  endTdmRound,
   computeBulletDamage,
   computeCooldown
 };

--- a/test/gameLogic.test.js
+++ b/test/gameLogic.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 const { test } = require('node:test');
 
 const gameState = require('../src/models/gameState');
-const { spawnPlayer } = require('../src/services/gameLogic');
+const { spawnPlayer, endTdmRound } = require('../src/services/gameLogic');
 
 test('spawnPlayer positions players based on team in classic mode', () => {
   gameState.mode = 'classic';
@@ -25,4 +25,14 @@ test('spawnPlayer uses random positions in tdm mode', () => {
   spawnPlayer(p);
   assert.ok(p.x >= 50 && p.x <= gameState.canvasWidth / 2 - 50);
   assert.ok(p.y >= 50 && p.y <= gameState.canvasHeight - 50);
+});
+
+test('endTdmRound retains start time on final round', () => {
+  gameState.mode = 'tdm';
+  gameState.maxRounds = 2;
+  gameState.currentRound = 1;
+  gameState.gameStartTime = 12345;
+  endTdmRound('left');
+  assert.ok(gameState.forceGameOver);
+  assert.notStrictEqual(gameState.gameStartTime, null);
 });


### PR DESCRIPTION
## Summary
- keep `gameStartTime` so the game over state triggers after the last TDM round
- expose `endTdmRound` for tests
- test that final rounds retain the start time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68828123635c83288879264688a28bfa