### PR TITLE
feat: add player body assets support

### DIFF
--- a/assets/Players Bodies/.gitkeep
+++ b/assets/Players Bodies/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder for player body assets

--- a/views/game1 - Battle/game.ejs
+++ b/views/game1 - Battle/game.ejs
@@ -396,10 +396,9 @@
       }
     }
 
-    const blueSprite = new Image();
-    blueSprite.src = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%23007BFF' stroke='%230056b3' stroke-width='4'/></svg>";
-    const redSprite = new Image();
-    redSprite.src = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%23FF4136' stroke='%23d62d20' stroke-width='4'/></svg>";
+    const playerBody = new Image();
+    // Asset will be provided in assets/Players Bodies by future commits
+    playerBody.src = "/assets/Players%20Bodies/body.png";
     const bulletSprites = { left: [], right: [] };
     for (let i = 32; i < 40; i++) {
       const idx = String(i).padStart(3, '0');
@@ -433,10 +432,13 @@
     }
 
     function drawPlayer(p, data){
-      const sprite = p.team === 'left' ? blueSprite : redSprite;
       const faded = data.mode === 'tdm' && !p.isAlive;
       if (faded) ctx.globalAlpha = 0.35;
-      ctx.drawImage(sprite, p.x - p.radius, p.y - p.radius, p.radius * 2, p.radius * 2);
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      if (p.team === 'right') ctx.scale(-1, 1);
+      ctx.drawImage(playerBody, -p.radius, -p.radius, p.radius * 2, p.radius * 2);
+      ctx.restore();
       if (faded) { ctx.globalAlpha = 1; return; }
 
       const barWidth  = p.radius * 2;

--- a/views/game1 - Battle/pc.ejs
+++ b/views/game1 - Battle/pc.ejs
@@ -256,10 +256,9 @@ let currentTeam = null;
   /* ========================================================
     5.  SPRITES
   ======================================================== */
-  const blueShip = new Image();
-  blueShip.src   = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%2300b3ff' stroke='%230087cc' stroke-width='4'/></svg>";
-  const redShip  = new Image();
-  redShip.src    = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='40' height='40'><circle cx='20' cy='20' r='18' fill='%23ff273d' stroke='%23c40027' stroke-width='4'/></svg>";
+  const playerBody = new Image();
+  // Placeholder; actual assets will be added under assets/Players Bodies
+  playerBody.src = "/assets/Players%20Bodies/body.png";
 
   const bulletSprites = { left: [], right: [] };
   for (let i = 32; i < 40; i++) {
@@ -286,10 +285,13 @@ let currentTeam = null;
   function drawPlayers(players, mode) {
     for (const id in players) {
       const p = players[id];
-      const spr = p.team === 'left' ? blueShip : redShip;
       const faded = mode==='tdm' && !p.isAlive;
       if (faded) ctx.globalAlpha = 0.35;
-      ctx.drawImage(spr, p.x - p.radius, p.y - p.radius, p.radius * 2, p.radius * 2);
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      if (p.team === 'right') ctx.scale(-1, 1);
+      ctx.drawImage(playerBody, -p.radius, -p.radius, p.radius * 2, p.radius * 2);
+      ctx.restore();
       if (faded) { ctx.globalAlpha = 1; continue; }
 
       /* bars */


### PR DESCRIPTION
## Summary
- add placeholder `Players Bodies` asset directory for player sprites
- render players using new body sprite and mirror right team

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d391595c8328b4d7c188bcc5466a