### PR TITLE
Fix skin popup to list player skins from assets folder

### DIFF
--- a/src/controllers/gameController.js
+++ b/src/controllers/gameController.js
@@ -15,10 +15,9 @@ module.exports = (app) => {
     } catch (e) {}
     let playerSkins = [];
     try {
-      const skinDir = path.join(__dirname, '../../assets/PlayerSkins');
+      const skinDir = path.join(__dirname, '../../assets/PlayersSkins');
       playerSkins = fs.readdirSync(skinDir)
-        .filter(f => f.toLowerCase().endsWith('.png'))
-        .map(f => `PlayerSkins/${f}`);
+        .filter(f => f.toLowerCase().endsWith('.png'));
     } catch (e) {}
     res.render(view, {
       joinURL: app.locals.joinURL,


### PR DESCRIPTION
## Summary
- load PNG skins from assets/PlayersSkins for skin selection popup
- return plain file names so /skin service can normalize images wherever they're displayed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bab8ff7dd48328a261e55e12623d7c