### PR TITLE
Double entity sizes and fix right-team skin orientation

### DIFF
--- a/src/services/gameLogic.js
+++ b/src/services/gameLogic.js
@@ -279,7 +279,8 @@ function startGameLoop(io) {
         const dx = bullet.x - player.x;
         const dy = bullet.y - player.y;
         const distSq = dx * dx + dy * dy;
-        const rad = bullet.radius + player.radius;
+        const effectiveRadius = player.radius * (player.shield > 0 ? 1.5 : 1);
+        const rad = bullet.radius + effectiveRadius;
         if (distSq < rad * rad) {
             let dmgAmount = bullet.damage;
             if (player.shield > 0) {
@@ -292,7 +293,7 @@ function startGameLoop(io) {
             if (ioInstance) {
               ioInstance.emit('damagePopup', {
                 x: player.x,
-                y: player.y - player.radius,
+                y: player.y - effectiveRadius,
                 amount: Math.ceil(dmgAmount)
               });
             }
@@ -387,7 +388,7 @@ function createBulletWithAngle(player, angle, bounce=false, damageMod=1, sizeMod
   gameState.bullets.push({
     x: player.x,
     y: player.y,
-    radius: (5 + (Math.min(player.bulletDamage,5) - 1) * 2) * sizeMod,
+    radius: (5 + (Math.min(player.bulletDamage,5) - 1) * 2) * sizeMod * 2,
     team: player.team,
     color: '#fff',
     speedX: bulletSpeed * Math.cos(rad),
@@ -615,7 +616,7 @@ function createBot(team) {
     moveAngle: Math.random() * 360,
     baseSpeed: 3,
     speed: 3,
-    radius: 20,
+    radius: 40,
     shield: 0,
     shieldMax: 0,
     upgrades: {},

--- a/src/services/skinService.js
+++ b/src/services/skinService.js
@@ -19,7 +19,8 @@ async function getSkinImage(filePath, width, height, flipHoriz = false) {
     throw new Error('Invalid skin path');
   }
   let img = sharp(fullPath).resize(width, height);
-  if (flipHoriz) img = img.flip();
+  // Use horizontal flip (flop) so right-side team faces left
+  if (flipHoriz) img = img.flop();
   return img.png().toBuffer();
 }
 

--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -61,7 +61,7 @@ function initSocket(io) {
         moveAngle: undefined,
         baseSpeed: 3,
         speed: 3,
-        radius: 20,
+        radius: 40,
         fillColor: TEAM_COLORS[team].fill,
         borderColor: TEAM_COLORS[team].border,
         shield: 0,
@@ -305,7 +305,7 @@ function initSocket(io) {
         p.lives = 3;
         p.baseSpeed = 3;
         p.speed = 3;
-        p.radius = 20;
+        p.radius = 40;
         p.shield = 0;
         p.shieldMax = 0;
         p.kills = 0;

--- a/views/game1 - Battle/game.ejs
+++ b/views/game1 - Battle/game.ejs
@@ -393,7 +393,7 @@
         } else if(shieldPct > 0){
           ctx.save();
           ctx.beginPath();
-          ctx.arc(p.x, p.y, p.radius + 4, 0, Math.PI * 2);
+          ctx.arc(p.x, p.y, p.radius * 1.5, 0, Math.PI * 2);
           ctx.lineWidth = 8 * shieldPct;
           ctx.strokeStyle = shieldColor;
           ctx.shadowColor = shieldColor;


### PR DESCRIPTION
## Summary
- Flip right-side team skins horizontally using Sharp's flop
- Double base player and bullet radii and expand shields by 50%

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bac305742483289a3acb3cb6fb43d7