### PR TITLE
Improve level and results UI

### DIFF
--- a/public/endGamePopup.js
+++ b/public/endGamePopup.js
@@ -5,7 +5,8 @@
       this.titleEl = el.querySelector('#winnerTitle');
       this.blueTable = el.querySelector('#winnerBlue');
       this.redTable = el.querySelector('#winnerRed');
-      this.scoreboardEl = el.querySelector('#scoreboard');
+      this.blueScoreEl = el.querySelector('#finalBlueScore');
+      this.redScoreEl = el.querySelector('#finalRedScore');
       this.timerEl = el.querySelector('#timer');
     }
     truncateName(name){
@@ -42,9 +43,8 @@
         this.titleEl.className = 'scoreBox';
         this.titleEl.textContent = 'Draw';
       }
-      if(this.scoreboardEl){
-        this.scoreboardEl.textContent = `Blue: ${Math.ceil(data.scoreBlue)} - Red: ${Math.ceil(data.scoreRed)}`;
-      }
+      if(this.blueScoreEl) this.blueScoreEl.textContent = Math.ceil(data.scoreBlue);
+      if(this.redScoreEl) this.redScoreEl.textContent = Math.ceil(data.scoreRed);
       const header = '<thead><tr><th>Name</th><th>Kills</th><th>Deaths</th><th>Assists</th><th>Damage</th><th>Score</th></tr></thead><tbody></tbody>';
       this.blueTable.innerHTML = header;
       this.redTable.innerHTML = header;

--- a/views/game1 - Battle/Views/winnerPopup.ejs
+++ b/views/game1 - Battle/Views/winnerPopup.ejs
@@ -1,6 +1,10 @@
 <div id="winnerPopup" class="popup">
   <div id="winnerPopupContent" class="winner-content">
-    <div id="winnerTitle" class="scoreBox" style="font-size:2.5rem"></div>
+    <div id="winnerHeader" style="display:flex;align-items:center;justify-content:center;gap:1rem;">
+      <div id="finalBlueScore" class="scoreBox scoreBlue">0</div>
+      <div id="winnerTitle" class="scoreBox" style="font-size:2.5rem"></div>
+      <div id="finalRedScore" class="scoreBox scoreRed">0</div>
+    </div>
     <div id="winnerPopupInner" class="mt-2">
       <div>
         <h3 style="color:var(--blue-team)">Blue Team</h3>
@@ -11,7 +15,7 @@
         <table id="winnerRed" class="table table-dark table-sm"></table>
       </div>
     </div>
-    <div class="mt-2"><span id="timer">Time: 0s</span> | <span id="scoreboard">Blue: 0 - Red: 0</span></div>
+    <div class="mt-2"><span id="timer">Time: 0s</span></div>
     <div class="mt-3">
       <button id="exitButton" class="popupBtn">Exit to Title</button>
       <button id="restartFinal" class="popupBtn">Restart</button>

--- a/views/game1 - Battle/game.ejs
+++ b/views/game1 - Battle/game.ejs
@@ -409,11 +409,8 @@
       ctx.font = nameSize + 'px Orbitron, sans-serif';
       ctx.fillStyle = '#ffffff';
       ctx.textAlign = 'center';
-      ctx.fillText(p.name || 'Anon', p.x, barY - 8);
-
-      ctx.font = 'bold 16px Orbitron, sans-serif';
-      ctx.fillStyle = '#000';
-      ctx.fillText(p.level, p.x, p.y + 6);
+      const displayName = `${p.name || 'Anon'} Lv${p.level}`;
+      ctx.fillText(displayName, p.x, barY - 8);
     }
 
     function getPlayerSprite(p){
@@ -704,9 +701,6 @@
       document.getElementById('pausePopup').style.display = 'none';
       cancelCountdown();
       endGameCtrl.show(lastGameData);
-      startCountdown(5, () => {
-        window.location.href = '/';
-      });
     });
     document.getElementById('restartFinal').addEventListener('click', () => {
       if(restartPending) return;


### PR DESCRIPTION
## Summary
- Move level indicator next to player names
- Show final scores beside the results title
- Remove auto return to title; use Exit and Restart buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bac8a990408328abcd330f7ef9cbcc