### PR TITLE
Add skin selection to mobile controller

### DIFF
--- a/src/controllers/mobileController.js
+++ b/src/controllers/mobileController.js
@@ -1,7 +1,16 @@
 // src/controllers/mobileController.js
+const fs = require('fs');
+const path = require('path');
+
 module.exports = (app) => {
   app.get('/space-battle/controller', (req, res) => {
-    res.render('game1 - Battle/mobile');
+    let playerSkins = [];
+    try {
+      const skinDir = path.join(__dirname, '../../assets/PlayersSkins');
+      playerSkins = fs.readdirSync(skinDir)
+        .filter(f => f.toLowerCase().endsWith('.png'));
+    } catch (e) {}
+    res.render('game1 - Battle/mobile', { playerSkins });
   });
 
   app.get('/game2/controller', (req, res) => {

--- a/src/services/networkService.js
+++ b/src/services/networkService.js
@@ -20,15 +20,20 @@ function getLocalIp() {
 }
 
 function publishService(localIp, port) {
-  if (!bonjour) {
-    bonjour = require('bonjour')();
+  if (process.env.NODE_ENV === 'test') return;
+  try {
+    if (!bonjour) {
+      bonjour = require('bonjour')();
+    }
+    // Advertise the service with a friendly name
+    publishedService = bonjour.publish({ name: 'Space Battle Pong', type: 'http', port });
+    publishedService.on('error', (err) => {
+      console.error('Bonjour service error:', err.message);
+    });
+    console.log(`Broadcasting as "Space Battle Pong" on port ${port}`);
+  } catch (err) {
+    console.warn('Bonjour service not started:', err.message);
   }
-  // Advertise the service with a friendly name
-  publishedService = bonjour.publish({ name: 'Space Battle Pong', type: 'http', port });
-  publishedService.on('error', (err) => {
-    console.error('Bonjour service error:', err.message);
-  });
-  console.log(`Broadcasting as "Space Battle Pong" on port ${port}`);
 }
 
 function stopService(callback) {

--- a/src/services/socketHandler.js
+++ b/src/services/socketHandler.js
@@ -73,7 +73,7 @@ function initSocket(io) {
         assists: 0,
         damage: 0,
         lastDamagedBy: null,
-        skin: null
+        skin: info?.skin || null
       };
       gameState.players[socket.id].maxLevel = gameState.levelCap;
       // Spawn the player immediately only if the game has already started

--- a/test/socketHandler.test.js
+++ b/test/socketHandler.test.js
@@ -13,7 +13,7 @@ before(async () => {
   // Start the server in a child process
   const serverPath = path.join(__dirname, '..', 'server.js');
   serverProcess = spawn(process.execPath, [serverPath], {
-    env: { ...process.env, PORT: `${SERVER_PORT}` },
+    env: { ...process.env, PORT: `${SERVER_PORT}`, NODE_ENV: 'test' },
     stdio: 'ignore'
   });
   // Give the server a moment to boot
@@ -36,12 +36,13 @@ test('joinWithName initializes player and returns playerInfo', async (t) => {
 
   const playerInfo = await new Promise((res) => {
     socket.once('playerInfo', (p) => res(p));
-    socket.emit('joinWithName', { name: 'Tester', device: 'mobile' });
+    socket.emit('joinWithName', { name: 'Tester', device: 'mobile', skin: 'spaceship-blue.png' });
   });
 
   assert.strictEqual(playerInfo.name, 'Tester');
   assert.ok(playerInfo.id);
   assert.ok(playerInfo.team === 'left' || playerInfo.team === 'right');
+  assert.strictEqual(playerInfo.skin, 'spaceship-blue.png');
 
   socket.disconnect();
 });

--- a/views/game1 - Battle/mobile.ejs
+++ b/views/game1 - Battle/mobile.ejs
@@ -10,6 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="/customScrollbar.css" />
 
   <!-- STYLES -->
   <style>
@@ -77,7 +78,9 @@
     .left-panel { flex: 1; display: flex; justify-content: center; align-items: center; }
 
     .right-panel {
-      width: clamp(220px, 35vmin, 320px);
+      flex: 0 0 auto;
+      min-width: clamp(220px, 35vmin, 320px);
+      width: fit-content;
       background: rgba(0, 0, 0, 0.45);
       backdrop-filter: blur(5px);
       display: flex;
@@ -85,6 +88,7 @@
       padding: 1rem;
       border-right: 2px solid rgba(255,255,255,0.15);
       overflow-y: auto;
+      overflow-x: visible;
     }
 
     /* --------‑‑‑ Responsive Portrait Adjustments ‑‑‑-------- */
@@ -92,6 +96,11 @@
       .controller-container { flex-direction: column; }
       .right-panel { width: 100%; height: 42vh; border-right: none; border-bottom: 1px solid rgba(255,255,255,0.15); overflow-y:auto; }
     }
+
+    /* ===== generic popups ===== */
+    .popup { position: fixed; inset: 0; display: none; flex-direction: column; align-items: center; justify-content: center; background: rgba(0,0,0,.85); padding: 1rem; z-index: 10002; text-align: center; }
+    .popupBtn { margin: .6rem; padding: .6rem 1.8rem; font-size: 1rem; background: var(--text-light); color: #000; border: none; border-radius: 6px; }
+    .popupBtn:hover { box-shadow: 0 0 6px var(--text-light); }
 
     /* --------‑‑‑ Joystick ‑‑‑-------- */
     #joystickContainer {
@@ -194,6 +203,7 @@
   <!-- Name Entry Screen -->
   <div id="nameEntry">
     <input type="text" id="playerName" class="form-control text-center" placeholder="Commander name" maxlength="20">
+    <button id="chooseSkin" class="btn btn-secondary"><i class="bi bi-person-bounding-box"></i> Choose Skin</button>
     <button id="submitName" class="btn btn-primary"><i class="bi bi-rocket-takeoff"></i> Join Game</button>
   </div>
 
@@ -202,7 +212,10 @@
     <div class="controller-container">
       <!-- Stats / Upgrades side -->
       <div class="right-panel">
-        <button id="leaderboardButton" class="btn btn-outline-light align-self-end mb-2" title="Leaderboard"><i class="bi bi-list-stars"></i></button>
+        <div class="d-flex align-self-end mb-2">
+          <button id="skinButton" class="btn btn-outline-light me-2" title="Change Skin"><i class="bi bi-person-bounding-box"></i></button>
+          <button id="leaderboardButton" class="btn btn-outline-light" title="Leaderboard"><i class="bi bi-list-stars"></i></button>
+        </div>
         <table class="table table-dark table-sm stats-table text-center mb-2">
           <tr><th><i class="bi bi-trophy-fill"></i> Level</th><td id="stat-level">0</td><td></td></tr>
           <tr><th><i class="bi bi-star-fill"></i> EXP</th><td id="stat-exp">0</td><td></td></tr>
@@ -223,6 +236,9 @@
     </div>
   </div>
 
+  <!-- Skins Popup -->
+  <%- include('Views/skinsPopup', { playerSkins: playerSkins }) %>
+
   <!-- Leaderboard Popup -->
   <%- include('Views/leaderboardPopupMobile') %>
 
@@ -232,6 +248,24 @@
   <script>
     const socket = io();
     let myPlayer = null;
+    let selectedSkin = null;
+
+    const skinsPopup = document.getElementById('skinsPopup');
+    const closeSkins = document.getElementById('closeSkins');
+    const skinOptions = document.querySelectorAll('#skinsGrid .skinOption');
+    const chooseSkinBtn = document.getElementById('chooseSkin');
+    const skinButton = document.getElementById('skinButton');
+    function openSkinPopup(){ skinsPopup.style.display='flex'; }
+    chooseSkinBtn.addEventListener('click', openSkinPopup);
+    skinButton.addEventListener('click', openSkinPopup);
+    closeSkins.addEventListener('click', ()=> skinsPopup.style.display='none');
+    skinOptions.forEach(img=>{
+      img.addEventListener('click', ()=>{
+        selectedSkin = img.dataset.skin;
+        skinsPopup.style.display='none';
+        if(myPlayer){ socket.emit('setSkin', { playerId: myPlayer.id, skin: selectedSkin }); }
+      });
+    });
 
     /* ---------- Orientation Handling ---------- */
     function checkOrientation() {
@@ -253,7 +287,7 @@
     document.getElementById('submitName').addEventListener('click', () => {
       const name = document.getElementById('playerName').value.trim();
       if (!name) return;
-      socket.emit('joinWithName', { name, device: 'mobile' });
+      socket.emit('joinWithName', { name, device: 'mobile', skin: selectedSkin });
       document.getElementById('nameEntry').style.display = 'none';
       document.getElementById('controllerUI').style.display = 'block';
       screen.orientation?.lock('landscape').catch(()=>{});


### PR DESCRIPTION
## Summary
- allow mobile controllers to pick and change player skins via a new popup
- make stats panel width flexible to reduce scrollbars
- handle bonjour gracefully during tests and cover skin option in join flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bacdbb8da08328aa28d172d6243601