### PR TITLE
Bridge AirConsole controllers to game server

### DIFF
--- a/public/AirConsole/screen.html
+++ b/public/AirConsole/screen.html
@@ -67,11 +67,11 @@
 
   // 4) Server -> Screen -> *Specific* Controller
   //    You’ll add tiny server changes to emit these "air:*" events back to the screen.
-  socket.on('air:playerInfo', ({ device_id, player }) => {
+  socket.on('air:playerInfo', ({ playerId, player }) => {
     // Remember mapping and send back to the originating controller:
-    deviceToPlayerId.set(device_id, player.id);
-    playerIdToDevice.set(player.id, device_id);
-    AC.message(device_id, { type: 'playerInfo', payload: player });
+    deviceToPlayerId.set(playerId, player.id);
+    playerIdToDevice.set(player.id, playerId);
+    AC.message(playerId, { type: 'playerInfo', payload: player });
   });
 
   socket.on('air:levelUp', ({ playerId }) => {


### PR DESCRIPTION
## Summary
- Relay controller messages through screen by wiring AirConsole join, input, upgrade, and skin events to the existing Socket.IO handlers.
- Broadcast game state and player events to AirConsole clients and handle controller disconnects.
- Update AirConsole screen to expect playerId for targeted replies.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5efef22c8328bf4a45b85c45a35a