### PR TITLE
Enable scrolling skin picker and mobile auto-reconnect

### DIFF
--- a/views/game1 - Battle/Views/skinsPopup.ejs
+++ b/views/game1 - Battle/Views/skinsPopup.ejs
@@ -1,5 +1,5 @@
 <div id="skinsPopup" class="popup">
-  <div id="skinsContainer" class="custom-scrollbar" style="max-width:600px;max-height:80vh;background:rgba(0,0,0,.6);padding:1rem;border:2px solid var(--neutral);border-radius:10px;">
+  <div id="skinsContainer" class="custom-scrollbar" style="max-width:600px;max-height:80vh;overflow-y:auto;background:rgba(0,0,0,.6);padding:1rem;border:2px solid var(--neutral);border-radius:10px;">
     <h3 class="mb-3">Select Skin</h3>
     <div id="skinsGrid" style="display:grid;grid-template-columns:repeat(3, 1fr);gap:0.5rem;justify-items:center;">
       <% playerSkins.forEach(function(s){ %>

--- a/views/game1 - Battle/mobile.ejs
+++ b/views/game1 - Battle/mobile.ejs
@@ -255,6 +255,15 @@
     const savedSkin = localStorage.getItem('playerSkin');
     if (savedSkin) selectedSkin = savedSkin;
 
+    socket.on('connect', () => {
+      const storedName = localStorage.getItem('playerName');
+      const storedSkin = localStorage.getItem('playerSkin');
+      if (storedSkin) selectedSkin = storedSkin;
+      if (storedName) {
+        socket.emit('joinWithName', { name: storedName, device: deviceId, skin: selectedSkin });
+      }
+    });
+
     const skinsPopup = document.getElementById('skinsPopup');
     const closeSkins = document.getElementById('closeSkins');
     const skinOptions = document.querySelectorAll('#skinsGrid .skinOption');
@@ -291,7 +300,6 @@
 
     if (savedName) {
       document.getElementById('playerName').value = savedName;
-      socket.emit('joinWithName', { name: savedName, device: deviceId, skin: savedSkin });
       document.getElementById('nameEntry').style.display = 'none';
       document.getElementById('controllerUI').style.display = 'block';
       screen.orientation?.lock('landscape').catch(()=>{});


### PR DESCRIPTION
## Summary
- Allow skin picker popup to scroll through long skin lists
- Automatically rejoin mobile controllers using stored name and skin after reconnects

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd6540cf988328846f2c2864a2c01b