### PR TITLE
Make skins popup scrollable

### DIFF
--- a/views/game1 - Battle/Views/skinsPopup.ejs
+++ b/views/game1 - Battle/Views/skinsPopup.ejs
@@ -1,5 +1,5 @@
 <div id="skinsPopup" class="popup">
-  <div id="skinsContainer" class="custom-scrollbar" style="max-width:600px;max-height:80vh;background:rgba(0,0,0,.6);padding:1rem;border:2px solid var(--neutral);border-radius:10px;">
+  <div id="skinsContainer" class="custom-scrollbar" style="max-width:600px;max-height:80vh;background:rgba(0,0,0,.6);padding:1rem;border:2px solid var(--neutral);border-radius:10px;overflow-y:auto;">
     <h3 class="mb-3">Select Skin</h3>
     <div id="skinsGrid" style="display:grid;grid-template-columns:repeat(3, 1fr);gap:0.5rem;justify-items:center;">
       <% playerSkins.forEach(function(s){ %>


### PR DESCRIPTION
## Summary
- allow skin selection popup to scroll when many skins are present by enabling overflow on container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd6f802544832898f075e4a0ff477b